### PR TITLE
Let `*` match 0-or-more instead of 1-or-more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning].
 ## [Unreleased]
 
 - Fix bug where rules following a wildcard would not be matched.
+- Let `*` match 0-or-more instead of 1-or-more.
 
 ## [0.3.0] - 2024-11-03
 

--- a/src/ignores.js
+++ b/src/ignores.js
@@ -70,7 +70,9 @@ function isIgnored(config, path) {
 		}
 
 		if (rule === "*") {
-			const reason = isIgnored(config, remaining) || isIgnored(config[rule], remaining);
+			const reason = isIgnored(config, remaining)
+				|| isIgnored(config[rule], remaining)
+				|| isIgnored(config[rule], path);
 			if (!!reason) {
 				return reason;
 			} else {

--- a/src/ignores.test.js
+++ b/src/ignores.test.js
@@ -187,8 +187,8 @@ test("ignore.js", async (t) => {
 						"*": {
 							"bar@2.0.0": {
 								"#ignore": "ignored with wildcard",
-							}
-						}
+							},
+						},
 					},
 				},
 				deprecations: [
@@ -215,6 +215,86 @@ test("ignore.js", async (t) => {
 								path: [
 									{ name: "foo", version: "1.0.0" },
 									{ name: "some-package", version: "3.0.0" },
+									{ name: "bar", version: "2.0.0" },
+								],
+								reason: "ignored with wildcard",
+							},
+						],
+						kept: [],
+					},
+				],
+			},
+			{
+				config: {
+					"foo@1.0.0": {
+						"*": {
+							"bar@2.0.0": {
+								"#ignore": "ignored with wildcard",
+							},
+						},
+					},
+				},
+				deprecations: [
+					{
+						name: "bar",
+						version: "2.0.0",
+						reason: "foobar",
+						paths: [
+							[
+								{ name: "foo", version: "1.0.0" },
+								{ name: "bar", version: "2.0.0" },
+							],
+						],
+					},
+				],
+				want: [
+					{
+						name: "bar",
+						version: "2.0.0",
+						reason: "foobar",
+						ignored: [
+							{
+								path: [
+									{ name: "foo", version: "1.0.0" },
+									{ name: "bar", version: "2.0.0" },
+								],
+								reason: "ignored with wildcard",
+							},
+						],
+						kept: [],
+					},
+				],
+			},
+			{
+				config: {
+					"foo@1.0.0": {
+						"*": {
+							"#ignore": "ignored with wildcard",
+						},
+					},
+				},
+				deprecations: [
+					{
+						name: "bar",
+						version: "2.0.0",
+						reason: "foobar",
+						paths: [
+							[
+								{ name: "foo", version: "1.0.0" },
+								{ name: "bar", version: "2.0.0" },
+							],
+						],
+					},
+				],
+				want: [
+					{
+						name: "bar",
+						version: "2.0.0",
+						reason: "foobar",
+						ignored: [
+							{
+								path: [
+									{ name: "foo", version: "1.0.0" },
 									{ name: "bar", version: "2.0.0" },
 								],
 								reason: "ignored with wildcard",


### PR DESCRIPTION
Caused by https://github.com/ericcornelissen/shescape/pull/1762

## Summary

This makes the wildcard `*` properly match 0-or-more when the dependency hierarchy is `foo > bar` and the ignore directives is `foo > * > bar`.