### PR TITLE
Handle wildcard not matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Fix bug where rules following a wildcard would not be matched.
 
 ## [0.3.0] - 2024-11-03
 

--- a/src/ignores.js
+++ b/src/ignores.js
@@ -70,7 +70,12 @@ function isIgnored(config, path) {
 		}
 
 		if (rule === "*") {
-			return isIgnored(config, remaining) || isIgnored(config[rule], remaining);
+			const reason = isIgnored(config, remaining) || isIgnored(config[rule], remaining);
+			if (!!reason) {
+				return reason;
+			} else {
+				continue;
+			}
 		}
 
 		const [name, version] = parseRule(rule);

--- a/src/ignores.test.js
+++ b/src/ignores.test.js
@@ -301,6 +301,50 @@ test("ignore.js", async (t) => {
 					},
 				],
 			},
+			{
+				config: {
+					"foo@1.0.0": {
+						"*": {
+							"baz@3.0.0": {
+								"#ignore": "ignored with wildcard",
+							}
+						},
+						"bar@2.0.0": {
+							"#ignore": "ignored with wildcard",
+						}
+					},
+				},
+				deprecations: [
+					{
+						name: "bar",
+						version: "2.0.0",
+						reason: "foobar",
+						paths: [
+							[
+								{ name: "foo", version: "1.0.0" },
+								{ name: "bar", version: "2.0.0" },
+							],
+						],
+					},
+				],
+				want: [
+					{
+						name: "bar",
+						version: "2.0.0",
+						reason: "foobar",
+						ignored: [
+							{
+								path: [
+									{ name: "foo", version: "1.0.0" },
+									{ name: "bar", version: "2.0.0" },
+								],
+								reason: "ignored with wildcard",
+							},
+						],
+						kept: [],
+					},
+				],
+			},
 		];
 
 		for (const i in goodTestCases) {


### PR DESCRIPTION
## Summary

Fix a bug where, if a wildcard doesn't match, further rules in the same config level wouldn't be matched either even though they should.