### PR TITLE
Adjust & improve wildcard behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Add `+` to 1-or-more.
+- Let `*` properly match 0-or-more (i.e. match the dependency itself too).
 
 ## [0.3.1] - 2024-11-04
 

--- a/README.md
+++ b/README.md
@@ -75,15 +75,20 @@ For example:
     }
   },
 
-  "also-not-ignored@v4": {
+  "ignored-it@v4": {
     "*": {
-      "#ignore": "ignore all deprecations under also-not-ignored@v4"
+      "#ignore": "ignore deprecations in ignore-it@v4 and dependencies with '*'"
+    }
+  },
+  "also-not-ignored@v5": {
+    "+": {
+      "#ignore": "ignore deprecations *under* do-not-ignore@v4 with '+'"
     }
   },
 
   "*": {
-    "ignored@v5": {
-      "#ignore": "ignore deprecations in ignored@v5 anywhere in the tree"
+    "ignored@v6": {
+      "#ignore": "ignore deprecations in ignored@v6 anywhere in the tree"
     }
   }
 }


### PR DESCRIPTION
Relates to #22
Closes #26
Closes #27

## Summary

Update the `*` to match 0-or-more in the sense that it also ignores the dependency in which it is present. Add `+` to match 1-or-more.

This adds a convenient notation for ignoring "x-and-its-entire-tree", namely:

```json
{
  "foobar@1.0.0": {
    "*": {
      "#ignore": "ignore deprecation warnings in foo@1.0.0 and all its transitive dependencies"
    }
  }
}
```

It also enables a very simple configuration to ignore deprecation warnings for all transitive dependencies:

```json
{
  "+": {
    "+": {
      "#ignore": "ignore deprecation warnings in all its transitive dependencies"
    }
  }
}
```
