### PR TITLE
Test nightly against latest release of runtime dependencies

### DIFF
--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -1,0 +1,30 @@
+name: Nightly
+on:
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch: ~
+
+permissions: read-all
+
+jobs:
+  test:
+    name: Test against latest runtime dependency versions
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Install Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          cache: npm
+          node-version-file: .nvmrc
+      - name: Install dependencies
+        run: npm clean-install
+      - name: Bump runtime dependencies to latest compatible
+        run: |
+          npm update --omit dev --omit optional --omit peer
+          npm install
+      - name: Run tests
+        run: npm run test


### PR DESCRIPTION
Relates to #12
Relates to #16
Relates to #18

## Summary

Since we depend on the earliest version of runtime dependencies - in order to make sure we don't use anything introduced in a later version - we don't know for sure if we are still compatible with later versions of runtime dependencies. To fill this gap, this adds a nightly CI job that runs the project's test suite after upgrading all runtime dependencies to the latest compatible version.