### PR TITLE
Set up vulnerability auditing

### DIFF
--- a/.github/workflows/audit-dev.yml
+++ b/.github/workflows/audit-dev.yml
@@ -4,8 +4,8 @@ on:
     paths:
       - .github/workflows/audit-dev.yml
       - .ndmrc
+      - .nsprc
       - package-lock.json
-      - package.json
   push:
     branches:
       - main
@@ -32,4 +32,21 @@ jobs:
       - name: Install dependencies
         run: npm clean-install
       - name: Audit deprecations
-        run: npm run dogfeed
+        run: npm run audit:deprecations
+  vulnerabilities:
+    name: Vulnerabilities
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Install Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          cache: npm
+          node-version-file: .nvmrc
+      - name: Install dependencies
+        run: npm clean-install
+      - name: Audit vulnerabilities
+        run: npm run audit:vulnerabilities

--- a/.nsprc
+++ b/.nsprc
@@ -1,0 +1,3 @@
+{
+    "GHSA-c2qf-rxjj-qqgw": "fixed version is within the supported version range"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "depreman": "bin/cli.js"
       },
       "devDependencies": {
+        "better-npm-audit": "3.11.0",
         "licensee": "11.1.1",
         "lockfile-lint": "4.14.0",
         "ls-engines": "0.9.3",
@@ -1036,6 +1037,39 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/better-npm-audit": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/better-npm-audit/-/better-npm-audit-3.11.0.tgz",
+      "integrity": "sha512-/Pt05DK6HQaRjWDc5McsCkJBZYfhgQGneKnxzPJExtRq38NttO1Hm30m0GVQeZogE94LVNBVrhWwVsoCo+at3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.0.0",
+        "dayjs": "^1.10.6",
+        "lodash.get": "^4.4.2",
+        "semver": "^7.6.3",
+        "table": "^6.7.1"
+      },
+      "bin": {
+        "better-npm-audit": "index.js"
+      },
+      "engines": {
+        "node": ">= 8.12"
+      }
+    },
+    "node_modules/better-npm-audit/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/bin-links": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-4.0.4.tgz",
@@ -1352,6 +1386,16 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/common-ancestor-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
@@ -1514,6 +1558,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.3.7",
@@ -4253,6 +4304,13 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "npm": "^10"
   },
   "scripts": {
+    "audit": "npm run audit:deprecations && npm run audit:vulnerabilities",
+    "audit:deprecations": "npm run dogfeed",
+    "audit:vulnerabilities": "better-npm-audit audit",
     "coverage": "node --test --experimental-test-coverage 'src/*.test.js'",
     "dogfeed": "node bin/cli.js --errors-only",
     "licenses": "licensee --errors-only",
@@ -37,6 +40,7 @@
     "semver": "^7.0.0"
   },
   "devDependencies": {
+    "better-npm-audit": "3.11.0",
     "licensee": "11.1.1",
     "lockfile-lint": "4.14.0",
     "ls-engines": "0.9.3",


### PR DESCRIPTION
## Summary

Add [`better-npm-audit`](https://npmjs.com/package/better-npm-audit) as a means to audit for known vulnerabilities in dependencies. This was chosen over just running `npm audit` because it does not support ignoring known vulnerabilities.