### PR TITLE
Create script to check license headers for source files

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test:unit": "node --test 'src/*.test.js'",
     "test:e2e": "node --test 'test/e2e.test.js'",
     "verify": "npm run test && npm run vet && npm run licenses && npm run dogfeed",
-    "vet": "lockfile-lint && ls-engines && publint --strict && node check-runtime-deps.js"
+    "vet": "lockfile-lint && ls-engines && publint --strict && node script/check-headers.js && node script/check-runtime-deps.js"
   },
   "dependencies": {
     "chalk": "^5.0.0",

--- a/script/check-headers.js
+++ b/script/check-headers.js
@@ -1,0 +1,75 @@
+// MIT No Attribution
+//
+// Copyright 2024 Eric Cornelissen
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify,
+// merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as process from "node:process";
+
+const ignore = [
+	"bin/cli.js",
+	"node_modules",
+	"script",
+	"test/fixtures",
+];
+
+const header = `
+// Copyright (C) 2024  Eric Cornelissen
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, version 3 of the License only.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+`;
+
+let hasViolation = false;
+for await (const entry of jsFiles(".", ignore)) {
+	const result = await hasLicenseHeader(entry);
+	if (!result) {
+		console.log("Missing/incorrect license header in:", entry);
+		hasViolation = true;
+	}
+}
+
+if (hasViolation) process.exit(1);
+else console.log("No problems detected");
+
+// -----------------------------------------------------------------------------
+
+async function hasLicenseHeader(entry) {
+	const content = await fs.readFile(entry, { encoding: "utf-8" });
+	return content.startsWith(`${header.trimStart()}\n`);
+}
+
+async function* jsFiles(dir, exclude) {
+	for (let entry of await fs.readdir(dir)) {
+		entry = path.join(dir, entry);
+		if (exclude.includes(entry)) continue;
+
+		if ((await fs.stat(entry)).isFile()) {
+			if (path.extname(entry) === ".js") yield entry;
+		} else {
+			yield * await jsFiles(entry, exclude);
+		}
+	}
+}

--- a/script/check-runtime-deps.js
+++ b/script/check-runtime-deps.js
@@ -15,10 +15,10 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-import cp from "node:child_process";
-import fs from "node:fs";
-import path from "node:path";
-import process from "node:process";
+import * as cp from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as process from "node:process";
 
 const manifestPath = path.resolve(".", "package.json");
 const rawManifest = fs.readFileSync(manifestPath).toString();


### PR DESCRIPTION
Closes #15

## Summary

Add a second script that checks that a license header is present in all source files. This is to ensure every source file has the license stated explicitly and consistently.

A custom script was chosen over alternatives such as ESLint plugins because these generally were not flexible enough, not providing the capability to enforce strictly that the header should appear as is at the top of the file without any leading or trailing content AND have the comment be line-based (instead of a block comment).