### PR TITLE
Don't ignore expiry date with `*` wildcard rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning].
 ## [Unreleased]
 
 - Disallow expiry dates with prefixes or suffixes.
+- Fix ignoring of the expiry date when using the `*` wildcard.
 
 ## [0.3.3] - 2024-11-16
 

--- a/src/ignores.js
+++ b/src/ignores.js
@@ -116,7 +116,7 @@ function parseDecision(config) {
 }
 
 function isExpired(config) {
-	const expire = config["#expire"];
+	const expire = config["#expire"] ?? config["*"]?.["#expire"];
 	if (expire !== undefined) {
 		const expires = date.parse(expire);
 		const today = date.today();

--- a/src/ignores.test.js
+++ b/src/ignores.test.js
@@ -555,6 +555,49 @@ test("ignore.js", async (t) => {
 					},
 				],
 			},
+			"ignore with `#expire` under `*` wildcard": {
+				config: {
+					"package@1.0.0": {
+						"*": {
+							"#ignore": "expired",
+							"#expire": (() => {
+								const date = new Date();
+								const year = date.getFullYear();
+								const month = date.getMonth() + 1;
+								const day = date.getDate();
+								return `${year - 1}-${month}-${day}`;
+							})(),
+						},
+					},
+				},
+				deprecations: [
+					{
+						name: "package",
+						version: "1.0.0",
+						reason: "foobar",
+						paths: [
+							[
+								{ name: "package", version: "1.0.0" },
+							],
+						],
+					},
+				],
+				want: [
+					{
+						name: "package",
+						version: "1.0.0",
+						reason: "foobar",
+						ignored: [],
+						kept: [
+							{
+								path: [
+									{ name: "package", version: "1.0.0" },
+								],
+							},
+						],
+					},
+				],
+			},
 			"ignore directive after `*` wildcard matches": {
 				config: {
 					"foo@1.0.0": {


### PR DESCRIPTION
Without this change the expiry date in the following configuration would be ignored for `pacakge@1.0.0` by depreman.

```json
{
	"package@1.0.0": {
		"*": {
			"#ignore": "expired",
			"#expire": "2024-0101",
		}
	}
}
```