### PR TITLE
Don't allow prefixes and suffixes on `"#expiry"` dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Disallow expiry dates with prefixes or suffixes.
 
 ## [0.3.3] - 2024-11-16
 

--- a/src/date.js
+++ b/src/date.js
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-const dateExpr = /(?<yyyy>\d{4})-(?<mm>\d{1,2})-(?<dd>\d{1,2})/;
+const dateExpr = /^(?<yyyy>\d{4})-(?<mm>\d{1,2})-(?<dd>\d{1,2})$/;
 
 export class DepremanDate {
 	constructor({ year, month, day }) {

--- a/src/date.test.js
+++ b/src/date.test.js
@@ -333,6 +333,14 @@ test("date.js", async (t) => {
 				str: "25-01-01",
 				want: /^Error: invalid date '25-01-01' \(must be 'yyyy-mm-dd'\)$/,
 			},
+			{
+				str: "prefix2025-01-01",
+				want: /^Error: invalid date 'prefix2025-01-01' \(must be 'yyyy-mm-dd'\)$/,
+			},
+			{
+				str: "2025-01-01suffix",
+				want: /^Error: invalid date '2025-01-01suffix' \(must be 'yyyy-mm-dd'\)$/,
+			},
 		];
 
 		for (const testCase of badTestCases) {


### PR DESCRIPTION
Without this change depreman would consider dates such as `foo2024-01-01` or `2024-01-01bar` as valid. This was because the regular expression for matching dates did not use start and end anchors.