### PR TITLE
Add `--report-only` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning].
 
 ## [Unreleased]
 
+- Add `--report-unused` flag to report on unnecessary ignore directives.
 - Disallow expiry dates with prefixes or suffixes.
 - Fix ignoring of the expiry date when using the `*` wildcard.
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "audit:vulnerabilities": "better-npm-audit audit",
     "coverage": "npm run coverage:unit",
     "coverage:unit": "node --test --experimental-test-coverage 'src/*.test.js'",
-    "dogfeed": "node bin/cli.js --errors-only",
+    "dogfeed": "node bin/cli.js --errors-only --report-unused",
     "licenses": "licensee --errors-only",
     "test": "npm run test:unit && npm run test:e2e",
     "test:unit": "node --test 'src/*.test.js'",

--- a/src/cli.js
+++ b/src/cli.js
@@ -18,14 +18,15 @@ import { argv, exit } from "node:process";
 import { readConfig } from "./config.js";
 import { obtainDeprecations } from "./deprecations.js";
 import { obtainDependencyPaths } from "./hierarchy.js";
-import { removeIgnored } from "./ignores.js";
+import { removeIgnored, unusedIgnores } from "./ignores.js";
 import { printAndExit } from "./output.js";
 
 const help = argv.includes("--help") || argv.includes("-h");
 const everything = !(argv.includes("--errors-only"));
+const reportUnused = argv.includes("--report-unused");
 
 if (help) {
-	console.log(`depreman [-h|--help] [--errors-only]
+	console.log(`depreman [-h|--help] [--errors-only] [--report-unused]
 
 Manage npm deprecation.  Create an '.ndmrc' file with a JSON-based configuration
 to ignore npm deprecation warnings for your dependencies.
@@ -34,6 +35,8 @@ to ignore npm deprecation warnings for your dependencies.
       Show this help message.
    --errors-only
       Only output deprecations that are not ignored.
+   --report-unused
+      Report and fail for unused ignore directives.
 `);
 		exit(0);
 }
@@ -45,7 +48,8 @@ try {
 	]);
 
 	const result = removeIgnored(config, deprecations);
-	printAndExit(result, { everything });
+	const unused = reportUnused ? unusedIgnores(config) : [];
+	printAndExit(result, unused, { everything });
 } catch (error) {
 	console.error("error:", error.message);
 	exit(2);

--- a/src/output.js
+++ b/src/output.js
@@ -16,7 +16,7 @@ import { exit } from "node:process";
 
 import chalk from "chalk";
 
-export function printAndExit(result, options) {
+export function printAndExit(result, unused, options) {
 	let exitCode = 0;
 
 	for (const pkg of result) {
@@ -39,6 +39,14 @@ export function printAndExit(result, options) {
 				const msg = `\t. > ${path.map(pkgToString).join(" > ")}\n\t\t${chalk.italic(prefix)}`;
 				console.log(chalk.dim(msg));
 			}
+		}
+	}
+
+	if (unused?.length > 0) {
+		exitCode = 1;
+		console.log("Unused ignore directives(s):");
+		for (const path of unused) {
+			console.log(`\t. > ${path.join(" > ")}`);
 		}
 	}
 


### PR DESCRIPTION
Closes #5

## Summary

Update the CLI with a new option, `--report-only`, that can be used to detect `"#ignore"` directives that are not used by depreman and could be removed from the configuration file.