### PR TITLE
Add expiry date validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning].
 
 - Add `--omit=<dev|optional|peer>` flag to control the review scope.
 - Fix an unexpected runtime error if there are no dependencies.
+- Add validation of expiry dates.
 
 ## [0.3.4] - 2024-12-09
 

--- a/src/date.js
+++ b/src/date.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2024  Eric Cornelissen
+// Copyright (C) 2024-2025  Eric Cornelissen
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
@@ -15,10 +15,14 @@
 const dateExpr = /^(?<yyyy>\d{4})-(?<mm>\d{1,2})-(?<dd>\d{1,2})$/;
 
 export class DepremanDate {
-	constructor({ year, month, day }) {
-		this.year = year;
-		this.month = month;
-		this.day = day;
+	constructor(date) {
+		if (!isValid(date)) {
+			throw new Error(`invalid date '${year}-${month}-${day}'`);
+		}
+
+		this.year = date.year;
+		this.month = date.month;
+		this.day = date.day;
 	}
 
 	is(that) {
@@ -72,3 +76,26 @@ export function today() {
 		day: date.getDate(),
 	});
 }
+
+/**
+ * Determine if a raw (unverified) date is a valid date.
+ *
+ * The year is validated in a way to catch likely mistakes for the purposes of
+ * an expiry date (e.g. a year past 10.000 is probably not intended as an expiry
+ * date). The day is validated approximately, not considering the month.
+ *
+ * @param {RawDate} rawDate A potential date.
+ * @returns {boolean} `true` if the date is valid, `false` otherwise.
+ */
+function isValid({ year, month, day }) {
+	return year >= 2000 && year <= 9999
+		&& month >= 1 && month <= 12
+		&& day >= 1 && day <= 31;
+}
+
+/**
+ * @typedef RawDate
+ * @property {number} year
+ * @property {number} month
+ * @property {number} day
+ */

--- a/src/date.test.js
+++ b/src/date.test.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2024  Eric Cornelissen
+// Copyright (C) 2024-2025  Eric Cornelissen
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
@@ -23,6 +23,105 @@ import {
 
 test("date.js", async (t) => {
 	await t.test("DepremanDate", async (t) => {
+		await t.test("constructor", async (t) => {
+			const goodCases = {
+				"earliest month and day": {
+					year: 2025,
+					month: 1,
+					day: 1,
+				},
+				"earliest month": {
+					year: 2025,
+					month: 1,
+					day: 4,
+				},
+				"earliest day": {
+					year: 2025,
+					month: 2,
+					day: 1,
+				},
+				"latest month and day": {
+					year: 2025,
+					month: 12,
+					day: 31,
+				},
+				"latest month": {
+					year: 2025,
+					month: 12,
+					day: 4,
+				},
+				"latest day": {
+					year: 2025,
+					month: 2,
+					day: 31,
+				},
+			};
+
+			for (const [name, testCase] of Object.entries(goodCases)) {
+				await t.test(name, () => {
+					assert.doesNotThrow(() => {
+						new DepremanDate(testCase)
+					});
+				});
+			}
+
+			const badCases = {
+				"month 0": {
+					year: 2025,
+					month: 0,
+					day: 1,
+				},
+				"month 13": {
+					year: 2025,
+					month: 13,
+					day: 1,
+				},
+				"day 32": {
+					year: 2025,
+					month: 1,
+					day: 32,
+				},
+				"day 0": {
+					year: 2025,
+					month: 1,
+					day: 0,
+				},
+				"negative month": {
+					year: 2025,
+					month: -1,
+					day: 1,
+				},
+				"negative day": {
+					year: 2025,
+					month: 1,
+					day: -1,
+				},
+				"negative year (catch likely mistakes in the year)": {
+					year: -2025,
+					month: 1,
+					day: 1,
+				},
+				"too far in the past (catch likely mistakes in the year)": {
+					year: 1025,
+					month: 1,
+					day: 1,
+				},
+				"too far in the future (catch likely mistakes in the year)": {
+					year: 20025,
+					month: 1,
+					day: 1,
+				},
+			};
+
+			for (const [name, testCase] of Object.entries(badCases)) {
+				await t.test(name, () => {
+					assert.throws(() => {
+						new DepremanDate(testCase)
+					});
+				});
+			}
+		});
+
 		await t.test("is", async (t) => {
 			const trueCases = {
 				"sample, 2025-01-01": {


### PR DESCRIPTION
Closes #47 

## Summary

Update the `DepremanDate` class implementation with validation of the dates so that expiry dates will be verified. The validation here is not perfect but considered good enough (would be happy with a correct implementation if it is contributed along with an exhaustive suite of tests).

The year is intentionally validated to be in between a specific range, rather than any (perhaps positive) number - which all constitute a technically valid year - because we would like to catch mistakes in the year. For example, the year `226` is probably intended to be `2026` (but the author didn't quite press the `0` key), just like the year `1026` (pressed `1` instead of `2`) or `20026` (accidentally double pressed the `0` key).