### PR TITLE
Output deprecation warnings alphabetically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning].
 ## [Unreleased]
 
 - Add `--omit=<dev|optional|peer>` flag to control the review scope.
+- Make the output ordered alphabetically (by package name).
 - Fix an unexpected runtime error if there are no dependencies.
 
 ## [0.3.4] - 2024-12-09

--- a/src/output.js
+++ b/src/output.js
@@ -23,7 +23,7 @@ export function printAndExit(result, unused, options, chalk) {
 	let exitCode = 0;
 	const output = [];
 
-	for (const pkg of result) {
+	for (const pkg of result.sort(byName)) {
 		const id = pkgToString(pkg);
 		if (pkg.kept.length > 0) {
 			exitCode = 1;
@@ -62,7 +62,18 @@ export function printAndExit(result, unused, options, chalk) {
 }
 
 /**
- * @param {Result} pkg
+ * @param {Package} pkgA
+ * @param {Package} pkgB
+ * @returns {-1 | 0 | 1}
+ */
+function byName(pkgA, pkgB) {
+	const a = pkgToString(pkgA);
+	const b = pkgToString(pkgB);
+	return a.localeCompare(b);
+}
+
+/**
+ * @param {Package} pkg
  * @returns {string}
  */
 function pkgToString(pkg) {

--- a/src/output.test.js
+++ b/src/output.test.js
@@ -157,6 +157,72 @@ test("output.js", async (t) => {
 	. > foobar@3.1.4`,
 				}
 			},
+			"two deprecation which are not ignored (in order)": {
+				options: {
+					everything: false,
+				},
+				results: [
+					{
+						name: "bar",
+						version: "3.1.4",
+						reason: "no longer maintained",
+						kept: [
+							{ path: [{ name: "bar", version: "3.1.4" }] }
+						],
+						ignored: [],
+					},
+					{
+						name: "foo",
+						version: "2.7.1",
+						reason: "not maintained anymore",
+						kept: [
+							{ path: [{ name: "foo", version: "2.7.1" }] }
+						],
+						ignored: [],
+					},
+				],
+				unused: [],
+				want: {
+					exitCode: 1,
+					report: `bar@3.1.4 ${styler.italic(`("no longer maintained")`)}:
+	. > bar@3.1.4
+foo@2.7.1 ${styler.italic(`("not maintained anymore")`)}:
+	. > foo@2.7.1`,
+				}
+			},
+			"two deprecation which are not ignored (out of order)": {
+				options: {
+					everything: false,
+				},
+				results: [
+					{
+						name: "foo",
+						version: "2.7.1",
+						reason: "not maintained anymore",
+						kept: [
+							{ path: [{ name: "foo", version: "2.7.1" }] }
+						],
+						ignored: [],
+					},
+					{
+						name: "bar",
+						version: "3.1.4",
+						reason: "no longer maintained",
+						kept: [
+							{ path: [{ name: "bar", version: "3.1.4" }] }
+						],
+						ignored: [],
+					},
+				],
+				unused: [],
+				want: {
+					exitCode: 1,
+					report: `bar@3.1.4 ${styler.italic(`("no longer maintained")`)}:
+	. > bar@3.1.4
+foo@2.7.1 ${styler.italic(`("not maintained anymore")`)}:
+	. > foo@2.7.1`,
+				}
+			},
 			"one unused ignore": {
 				options: {
 					everything: false,


### PR DESCRIPTION
Closes #37


Update the output to always be alphabetically ordered by the package name (and in case a given package occurs multiple times, the version). This should help users search through the output more reliably and also makes the results bit-by-bit reproducible, which is nice to have.