### PR TITLE
Introduce `Result` and refactor `config.js` to not throw internally

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,7 +24,7 @@ export default [
 			"capitalized-comments": ["error", "always",{
 				ignoreConsecutiveComments: true,
 			}],
-			"class-methods-use-this": "error",
+			"class-methods-use-this": "off",
 			"complexity": "off",
 			"consistent-return": "off",
 			"consistent-this": "error",
@@ -47,7 +47,7 @@ export default [
 			"id-match": "error",
 			"init-declarations": "error",
 			"logical-assignment-operators": "error",
-			"max-classes-per-file": "error",
+			"max-classes-per-file": "off",
 			"max-depth": "error",
 			"max-lines": "error",
 			"max-lines-per-function": "error",

--- a/src/result.js
+++ b/src/result.js
@@ -1,0 +1,104 @@
+// Copyright (C) 2025  Eric Cornelissen
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, version 3 of the License only.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * @template O, E
+ * @typedef Result<O, E>
+ * @property {function(): E} error
+ * @property {function(): boolean} isErr
+ * @property {function(): boolean} isOk
+ * @property {function(): O} value
+ */
+
+/**
+ * @class
+ * @template T
+ */
+export class Ok {
+	/**
+	 * @param {T} value
+	 */
+	constructor(value) {
+		this.v = value;
+	}
+
+	/**
+	 * @throws {TypeError}
+	 */
+	error() {
+		throw new TypeError("Ok has no error");
+	}
+
+	/**
+	 * @returns {boolean}
+	 */
+	isErr() {
+		return false;
+	}
+
+	/**
+	 * @returns {boolean}
+	 */
+	isOk() {
+		return true;
+	}
+
+	/**
+	 * @returns {T}
+	 */
+	value() {
+		return this.v;
+	}
+}
+
+/**
+ * @class
+ * @template T
+ */
+export class Err {
+	/**
+	 * @param {T} error
+	 */
+	constructor(error) {
+		this.e = error;
+	}
+
+	/**
+	 * @returns {T}
+	 */
+	error() {
+		return this.e;
+	}
+
+	/**
+	 * @returns {boolean}
+	 */
+	isErr() {
+		return true;
+	}
+
+	/**
+	 * @returns {boolean}
+	 */
+	isOk() {
+		return false;
+	}
+
+	/**
+	 * @throws {TypeError}
+	 */
+	value() {
+		throw new TypeError("Err has no value");
+	}
+}

--- a/src/result.test.js
+++ b/src/result.test.js
@@ -1,0 +1,98 @@
+// Copyright (C) 2025  Eric Cornelissen
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, version 3 of the License only.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import * as assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { Err, Ok } from "./result.js";
+
+test("result.js", async (t) => {
+	await t.test("Err", async (t) => {
+		const value = "Hello error!";
+
+		await t.test("error", () => {
+			const err = new Err(value);
+
+			const got = err.error();
+			const want = value;
+			assert.equal(got, want);
+		});
+
+		await t.test("isErr", () => {
+			const err = new Err(value);
+
+			const got = err.isErr();
+			const want = true;
+			assert.equal(got, want);
+		});
+
+		await t.test("isOk", () => {
+			const err = new Err(value);
+
+			const got = err.isOk();
+			const want = false;
+			assert.equal(got, want);
+		});
+
+		await t.test("value", () => {
+			const err = new Err(value);
+
+			assert.throws(
+				() => err.value(),
+				{
+					name: 'TypeError',
+				},
+			);
+		});
+	});
+
+	await t.test("Ok", async (t) => {
+		const value = "Hello value!";
+
+		await t.test("error", () => {
+			const ok = new Ok(value);
+
+			assert.throws(
+				() => ok.error(),
+				{
+					name: 'TypeError',
+				},
+			);
+		});
+
+		await t.test("isErr", () => {
+			const ok = new Ok(value);
+
+			const got = ok.isErr();
+			const want = false;
+			assert.equal(got, want);
+		});
+
+		await t.test("isOk", () => {
+			const ok = new Ok(value);
+
+			const got = ok.isOk();
+			const want = true;
+			assert.equal(got, want);
+		});
+
+		await t.test("value", () => {
+			const ok = new Ok(value);
+
+			const got = ok.value();
+			const want = value;
+			assert.equal(got, want);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

This is the start of a refactoring effort to move away from throwing errors and towards `Result`s. The goal of this change is to make the control flow more explicit.