### PR TITLE
Improve tests based on mutation testing

### DIFF
--- a/.stryker.js
+++ b/.stryker.js
@@ -27,8 +27,8 @@ export default {
 
 	thresholds: {
 		high: 100,
-		low: 80,
-		break: 80,
+		low: 90,
+		break: 90,
 	},
 
 	tempDirName: "node_modules/.temp/stryker",

--- a/src/config.js
+++ b/src/config.js
@@ -80,4 +80,4 @@ function parseRawConfig(raw) {
 /**
  * @template O, E
  * @typedef {import("./result.js").Result<O, E>} Result
- * */
+ */

--- a/src/date.test.js
+++ b/src/date.test.js
@@ -25,6 +25,16 @@ test("date.js", async (t) => {
 	await t.test("DepremanDate", async (t) => {
 		await t.test("constructor", async (t) => {
 			const goodCases = {
+				"earliest valid date": {
+					year: 2000,
+					month: 1,
+					day: 1,
+				},
+				"latest valid date": {
+					year: 9999,
+					month: 12,
+					day: 31,
+				},
 				"earliest month and day": {
 					year: 2025,
 					month: 1,
@@ -115,9 +125,15 @@ test("date.js", async (t) => {
 
 			for (const [name, testCase] of Object.entries(badCases)) {
 				await t.test(name, () => {
-					assert.throws(() => {
-						new DepremanDate(testCase) // eslint-disable-line no-new
-					});
+					assert.throws(
+						() => {
+							new DepremanDate(testCase); // eslint-disable-line no-new
+						},
+						{
+							name: "Error",
+							message: /invalid date '.+?'/u,
+						},
+					);
 				});
 			}
 		});
@@ -310,25 +326,25 @@ test("date.js", async (t) => {
 				"next year": {
 					a: {
 						year: 2024,
-						month: 11,
-						day: 2,
+						month: 1,
+						day: 1,
 					},
 					b: {
 						year: 2023,
-						month: 1,
-						day: 1,
+						month: 11,
+						day: 2,
 					}
 				},
 				"next month": {
 					a: {
 						year: 2024,
 						month: 11,
-						day: 2,
+						day: 1,
 					},
 					b: {
 						year: 2024,
 						month: 10,
-						day: 1,
+						day: 2,
 					}
 				},
 				"next day": {
@@ -455,9 +471,11 @@ test("date.js", async (t) => {
 
 	await t.test("today", () => {
 		const got = today();
+		const want = new Date();
+
 		assert.ok(got instanceof DepremanDate);
-		assert.ok(got.year > 2000);
-		assert.ok(got.month >= 1 && got.month <= 12);
-		assert.ok(got.day >= 1 && got.day <= 31);
+		assert.equal(got.year, want.getFullYear());
+		assert.equal(got.month, want.getMonth() + 1);
+		assert.equal(got.day, want.getDate());
 	});
 });

--- a/src/output.js
+++ b/src/output.js
@@ -17,7 +17,7 @@
  * @param {Unused} unused
  * @param {Options} options
  * @param {Styler} chalk
- * @returns {{ ok: boolean, result: string }} The report and exit code.
+ * @returns {{ ok: boolean, result: string }}
  */
 export function printAndExit(result, unused, options, chalk) {
 	let ok = true;
@@ -47,7 +47,7 @@ export function printAndExit(result, unused, options, chalk) {
 		}
 	}
 
-	if (unused?.length > 0) {
+	if (unused.length > 0) {
 		ok = false;
 		output.push("Unused ignore directives(s):");
 		for (const path of unused) {

--- a/src/output.test.js
+++ b/src/output.test.js
@@ -123,7 +123,7 @@ test("output.js", async (t) => {
 							{
 								path: [{ name: "foobar", version: "3.1.4" }],
 								reason: true,
-							}
+							},
 						],
 					}
 				],
@@ -132,6 +132,35 @@ test("output.js", async (t) => {
 					ok: true,
 					report: `${styler.dim(`foobar@3.1.4`)}
 	${styler.dim(`. > foobar@3.1.4`)}
+		${styler.dim(`(allowed "no reason given")`)}`,
+				}
+			},
+			"one transitive deprecation which is ignored, everything": {
+				options: {
+					everything: true,
+				},
+				results: [
+					{
+						name: "bar",
+						version: "3.1.4",
+						reason: "no longer maintained",
+						kept: [],
+						ignored: [
+							{
+								path: [
+									{ name: "foo", version: "2.7.1" },
+									{ name: "bar", version: "3.1.4" },
+								],
+								reason: true,
+							}
+						],
+					}
+				],
+				unused: [],
+				want: {
+					ok: true,
+					report: `${styler.dim(`bar@3.1.4`)}
+	${styler.dim(`. > foo@2.7.1 > bar@3.1.4`)}
 		${styler.dim(`(allowed "no reason given")`)}`,
 				}
 			},
@@ -145,7 +174,7 @@ test("output.js", async (t) => {
 						version: "3.1.4",
 						reason: "no longer maintained",
 						kept: [
-							{ path: [{ name: "foobar", version: "3.1.4"}] }
+							{ path: [{ name: "foobar", version: "3.1.4" }] },
 						],
 						ignored: [],
 					}
@@ -155,6 +184,33 @@ test("output.js", async (t) => {
 					ok: false,
 					report: `foobar@3.1.4 ${styler.italic(`("no longer maintained")`)}:
 	. > foobar@3.1.4`,
+				}
+			},
+			"one transitive deprecation which is not ignored": {
+				options: {
+					everything: false,
+				},
+				results: [
+					{
+						name: "bar",
+						version: "3.1.4",
+						reason: "no longer maintained",
+						kept: [
+							{
+								path: [
+									{ name: "foo", version: "2.7.1" },
+									{ name: "bar", version: "3.1.4" },
+								],
+							},
+						],
+						ignored: [],
+					}
+				],
+				unused: [],
+				want: {
+					ok: false,
+					report: `bar@3.1.4 ${styler.italic(`("no longer maintained")`)}:
+	. > foo@2.7.1 > bar@3.1.4`,
 				}
 			},
 			"two deprecation which are not ignored (in order)": {

--- a/src/result.test.js
+++ b/src/result.test.js
@@ -51,7 +51,8 @@ test("result.js", async (t) => {
 			assert.throws(
 				() => err.value(),
 				{
-					name: 'TypeError',
+					name: "TypeError",
+					message: "Err has no value",
 				},
 			);
 		});
@@ -66,7 +67,8 @@ test("result.js", async (t) => {
 			assert.throws(
 				() => ok.error(),
 				{
-					name: 'TypeError',
+					name: "TypeError",
+					message: "Ok has no error",
 				},
 			);
 		});


### PR DESCRIPTION
Relates to #61

## Summary

Improve the test suites for `date.js`, `output.js`, and `result.js` based on mutation testing results. With these improvements, the minimum mutant coverage has been bumped to 90% (to avoid regression).