### PR TITLE
Wrap `semver.satisfies` return value in a Result

### DIFF
--- a/src/ignores.js
+++ b/src/ignores.js
@@ -97,7 +97,7 @@ function isIgnored(config, path) {
 
 		// Match name+semver
 		const [name, version] = parseRule(rule);
-		if (name === current.name && semver.satisfies(current.version, version)) {
+		if (name === current.name && semver.satisfies(current.version, version).value()) {
 			const reason = isIgnored(config[rule], remaining);
 			if (reason) {
 				return reason;

--- a/src/semver.js
+++ b/src/semver.js
@@ -13,12 +13,29 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import semverSatisfies from "semver/functions/satisfies.js";
+import semverValid from "semver/functions/valid.js";
+import semverValidRange from "semver/ranges/valid.js";
+
+import { Err, Ok } from "./result.js";
 
 /**
  * @param {string} version
  * @param {string} range
- * @returns {boolean}
+ * @returns {Result<boolean, string>}
  */
 export function satisfies(version, range) {
-	return semverSatisfies(version, range);
+	if (!semverValid(version)) {
+		return new Err(`'${version}' is not a valid semver version`);
+	}
+
+	if (!semverValidRange(range)) {
+		return new Err(`'${range}' is not a valid semver range`);
+	}
+
+	return new Ok(semverSatisfies(version, range));
 }
+
+/**
+ * @template O, E
+ * @typedef {import("./result.js").Result<O, E>} Result
+ */

--- a/src/semver.test.js
+++ b/src/semver.test.js
@@ -21,7 +21,7 @@ import {
 
 test("semver.js", async (t) => {
 	await t.test("satisfies", async (t) => {
-		const testCases = {
+		const goodCases = {
 			...{
 				"no range: exact match": {
 					version: "3.1.4",
@@ -424,12 +424,35 @@ test("semver.js", async (t) => {
 			},
 		};
 
-		for (const [name, testCase] of Object.entries(testCases)) {
+		for (const [name, testCase] of Object.entries(goodCases)) {
 			await t.test(name, () => {
 				const { version, range, want } = testCase;
 
 				const got = satisfies(version, range);
-				assert.equal(got, want);
+				assert.equal(got.value(), want);
+			});
+		}
+
+		const badCases = {
+			"version is invalid": {
+				version: "not a version",
+				range: "3.1.4",
+				want: "'not a version' is not a valid semver version",
+			},
+			"range is invalid": {
+				version: "3.1.4",
+				range: "not a range",
+				want: "'not a range' is not a valid semver range",
+			},
+		};
+
+		for (const [name, testCase] of Object.entries(badCases)) {
+			await t.test(name, () => {
+				const { version, range, want } = testCase;
+
+				const got = satisfies(version, range);
+				assert.ok(got.isErr());
+				assert.equal(got.error(), want)
 			});
 		}
 	});


### PR DESCRIPTION
Relates to #115

## Summary

Update the `semver.satisfies` function to check if the inputs are valid and return an `Err` if either is not. Correspondingly, return an `Ok` if the inputs are valid.
