### PR TITLE
Support npm projects without `package-lock.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Add support for projects that do not have a `package-lock.json`.
 
 ## [0.3.5] - 2025-01-23
 

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -61,6 +61,18 @@ test("end-to-end", async (t) => {
 		assert.equal(result.stdout, "");
 		assert.equal(result.stderr, "");
 	});
+
+	await t.test("without a lockfile", () => {
+		const lockfile = path.join(root, "test", "fixtures", "no-lockfile", "package-lock.json");
+		fs.rmSync(lockfile, { force: true });
+
+		const result = cli({
+			args: [],
+			project: fixture("no-lockfile"),
+		});
+
+		assert.equal(result.exitCode, 0);
+	});
 });
 
 const root = path.resolve(

--- a/test/fixtures/no-lockfile/.gitignore
+++ b/test/fixtures/no-lockfile/.gitignore
@@ -1,0 +1,1 @@
+package-lock.json

--- a/test/fixtures/no-lockfile/.ndmrc
+++ b/test/fixtures/no-lockfile/.ndmrc
@@ -1,0 +1,5 @@
+{
+  "*": {
+    "#ignore": "don't care about the deprecation warnings, just that a lockfile is not required"
+  }
+}

--- a/test/fixtures/no-lockfile/package.json
+++ b/test/fixtures/no-lockfile/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "semver": "7.0.0"
+  }
+}


### PR DESCRIPTION
Closes #90

## Summary

Add support for running this tool on projects that do not have a lockfile by falling back to running `npm install` for those projects.
