### PR TITLE
Implement CLI argument validation

### DIFF
--- a/.stryker.js
+++ b/.stryker.js
@@ -27,8 +27,8 @@ export default {
 
 	thresholds: {
 		high: 100,
-		low: 95,
-		break: 95,
+		low: 96,
+		break: 96,
 	},
 
 	tempDirName: "node_modules/.temp/stryker",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Add CLI argument validation and error messaging.
 
 ## [0.3.6] - 2025-03-17
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -26,9 +26,9 @@ export function parseArgv(argv) {
 	const omitPeer = removeFromList(argv, "--omit=peer");
 	const reportUnused = removeFromList(argv, "--report-unused");
 
-	const remaining = argv.filter((arg) => arg.startsWith("--"));
+	const remaining = argv.filter((arg) => arg.startsWith("-"));
 	if (remaining.length > 0) {
-		return new Err(`unknown flag(s): ${remaining}`);
+		return new Err(`spurious flag(s): ${remaining.join(", ")}`);
 	}
 
 	return new Ok({

--- a/src/cli.js
+++ b/src/cli.js
@@ -12,19 +12,24 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { Ok } from "./result.js";
+import { Err, Ok } from "./result.js";
 
 /**
  * @param {string[]} argv
- * @returns {Result<Config, null>}
+ * @returns {Result<Config, string>}
  */
 export function parseArgv(argv) {
-	const help = argv.includes("--help") || argv.includes("-h");
-	const everything = !(argv.includes("--errors-only"));
-	const omitDev = argv.includes("--omit=dev");
-	const omitOptional = argv.includes("--omit=optional");
-	const omitPeer = argv.includes("--omit=peer");
-	const reportUnused = argv.includes("--report-unused");
+	const help = removeFromList(argv, "--help") || removeFromList(argv, "-h");
+	const everything = !(removeFromList(argv, "--errors-only"));
+	const omitDev = removeFromList(argv, "--omit=dev");
+	const omitOptional = removeFromList(argv, "--omit=optional");
+	const omitPeer = removeFromList(argv, "--omit=peer");
+	const reportUnused = removeFromList(argv, "--report-unused");
+
+	const remaining = argv.filter((arg) => arg.startsWith("--"));
+	if (remaining.length > 0) {
+		return new Err(`unknown flag(s): ${remaining}`);
+	}
 
 	return new Ok({
 		help,
@@ -34,6 +39,21 @@ export function parseArgv(argv) {
 		omitPeer,
 		reportUnused,
 	});
+}
+
+/**
+ * @param {string[]} haystack
+ * @param {string} needle
+ * @returns {boolean}
+ */
+function removeFromList(haystack, needle) {
+	const i = haystack.indexOf(needle);
+	if (i === -1) {
+		return false;
+	}
+
+	haystack.splice(i, 1);
+	return true;
 }
 
 /**

--- a/src/cli.js
+++ b/src/cli.js
@@ -19,6 +19,7 @@ import { Err, Ok } from "./result.js";
  * @returns {Result<Config, string>}
  */
 export function parseArgv(argv) {
+	argv.splice(0, 2); // eslint-disable-line no-magic-numbers
 	const help = removeFromList(argv, "--help") || removeFromList(argv, "-h");
 	const everything = !(removeFromList(argv, "--errors-only"));
 	const omitDev = removeFromList(argv, "--omit=dev");
@@ -29,6 +30,10 @@ export function parseArgv(argv) {
 	const remaining = argv.filter((arg) => arg.startsWith("-"));
 	if (remaining.length > 0) {
 		return new Err(`spurious flag(s): ${remaining.join(", ")}`);
+	}
+
+	if (argv.length > 0) {
+		return new Err(`spurious arguments(s): ${argv.join(", ")}`);
 	}
 
 	return new Ok({

--- a/src/cli.test.js
+++ b/src/cli.test.js
@@ -83,5 +83,13 @@ test("cli.js", async (t) => {
 			assert.ok(got.isOk());
 			assert.ok(got.value().reportUnused);
 		});
+
+		await t.test("a flag that the CLI does not know", () => {
+			const arg = "--hello-world";
+			const argv = [...base, arg];
+			const got = parseArgv(argv);
+			assert.ok(got.isErr());
+			assert.equal(got.error(), `unknown flag(s): ${arg}`);
+		});
 	});
 });

--- a/src/cli.test.js
+++ b/src/cli.test.js
@@ -21,10 +21,10 @@ import {
 
 test("cli.js", async (t) => {
 	await t.test("parseArgv", async (t) => {
-		const base = ["depreman"];
+		const base = ["node", "depreman"];
 
 		await t.test("no flags", () => {
-			const argv = base;
+			const argv = [...base];
 			const got = parseArgv(argv);
 			assert.ok(got.isOk());
 			assert.ok(!got.value().help);
@@ -124,6 +124,25 @@ test("cli.js", async (t) => {
 				const got = parseArgv(argv);
 				assert.ok(got.isErr());
 				assert.equal(got.error(), "spurious flag(s): -h");
+			});
+		});
+
+		await t.test("argument the CLI does not expect", async (t) => {
+			await t.test("one argument", () => {
+				const arg = "foobar";
+				const argv = [...base, arg];
+				const got = parseArgv(argv);
+				assert.ok(got.isErr());
+				assert.equal(got.error(), `spurious arguments(s): ${arg}`);
+			});
+
+			await t.test("two argument", () => {
+				const arg1 = "foo";
+				const arg2 = "bar";
+				const argv = [...base, arg1, arg2];
+				const got = parseArgv(argv);
+				assert.ok(got.isErr());
+				assert.equal(got.error(), `spurious arguments(s): ${arg1}, ${arg2}`);
 			});
 		});
 	});

--- a/src/cli.test.js
+++ b/src/cli.test.js
@@ -84,12 +84,47 @@ test("cli.js", async (t) => {
 			assert.ok(got.value().reportUnused);
 		});
 
-		await t.test("a flag that the CLI does not know", () => {
-			const arg = "--hello-world";
-			const argv = [...base, arg];
+		await t.test("a repeated flag that the CLI does know", () => {
+			const arg = "--report-unused";
+			const argv = [...base, arg, arg];
 			const got = parseArgv(argv);
 			assert.ok(got.isErr());
-			assert.equal(got.error(), `unknown flag(s): ${arg}`);
+			assert.equal(got.error(), `spurious flag(s): ${arg}`);
+		});
+
+		await t.test("flags that the CLI does not know", async (t) => {
+			await t.test("one flag", () => {
+				const arg = "--hello-world";
+				const argv = [...base, arg];
+				const got = parseArgv(argv);
+				assert.ok(got.isErr());
+				assert.equal(got.error(), `spurious flag(s): ${arg}`);
+			});
+
+			await t.test("multiple flags", () => {
+				const arg1 = "--hello";
+				const arg2 = "--world";
+				const argv = [...base, arg1, arg2];
+				const got = parseArgv(argv);
+				assert.ok(got.isErr());
+				assert.equal(got.error(), `spurious flag(s): ${arg1}, ${arg2}`);
+			});
+		});
+
+		await t.test("both -h and --help", async (t) => {
+			await t.test("--help first", () => {
+				const argv = [...base, "--help", "-h"];
+				const got = parseArgv(argv);
+				assert.ok(got.isErr());
+				assert.equal(got.error(), "spurious flag(s): -h");
+			});
+
+			await t.test("-h first", () => {
+				const argv = [...base, "-h", "--help"];
+				const got = parseArgv(argv);
+				assert.ok(got.isErr());
+				assert.equal(got.error(), "spurious flag(s): -h");
+			});
 		});
 	});
 });

--- a/src/cli.test.js
+++ b/src/cli.test.js
@@ -133,7 +133,7 @@ test("cli.js", async (t) => {
 				const argv = [...base, arg];
 				const got = parseArgv(argv);
 				assert.ok(got.isErr());
-				assert.equal(got.error(), `spurious arguments(s): ${arg}`);
+				assert.equal(got.error(), `spurious argument(s): ${arg}`);
 			});
 
 			await t.test("two argument", () => {
@@ -142,7 +142,7 @@ test("cli.js", async (t) => {
 				const argv = [...base, arg1, arg2];
 				const got = parseArgv(argv);
 				assert.ok(got.isErr());
-				assert.equal(got.error(), `spurious arguments(s): ${arg1}, ${arg2}`);
+				assert.equal(got.error(), `spurious argument(s): ${arg1}, ${arg2}`);
 			});
 		});
 	});

--- a/src/main.js
+++ b/src/main.js
@@ -29,6 +29,11 @@ const EXIT_CODE_FAILURE = 1;
 const EXIT_CODE_UNEXPECTED = 2;
 
 const cliConfig = parseArgv(argv);
+if (cliConfig.isErr()) {
+	stderr.write(`${cliConfig.error()}\n`);
+	exit(EXIT_CODE_UNEXPECTED);
+}
+
 const {
 	help,
 	everything,


### PR DESCRIPTION
Closes #97
Relates to #61

## Summary

Update the `parseArgv` function to check for unknown flags and return an error if one is detected. This behavior is used in `main.js` to report the problem to the user and tested in `cli.test.js`.

~~TODO: validate other mistakes in the CLI args such as duplicate flags, both `-h` and `--help`, unexpected non-flag argument.~~

## Scope

The intended scope of this pull request is to do the validation. While it would be nice to have, suggestions to solve the problem (e.g. suggesting a flag with a similar name) is explicitly out of scope here.