### PR TITLE
Refactor and expand tests based on mutation testing

### DIFF
--- a/.stryker.js
+++ b/.stryker.js
@@ -27,8 +27,8 @@ export default {
 
 	thresholds: {
 		high: 100,
-		low: 92,
-		break: 92,
+		low: 95,
+		break: 95,
 	},
 
 	tempDirName: "node_modules/.temp/stryker",


### PR DESCRIPTION
Relates to #61

## Summary

Update the implementation and test suite of the [`deprecations.js` file](https://github.com/ericcornelissen/depreman/blob/82374a53aafd1fe942e754c94f25dd6fecb94b3a/src/deprecations.js) based on mutants detected by [Stryker](https://stryker-mutator.io/).