### PR TITLE
Add `fast-check` and start property testing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "better-npm-audit": "3.11.0",
         "eslint": "9.23.0",
         "eslint-plugin-regexp": "2.7.0",
+        "fast-check": "4.1.0",
         "lcov-total": "2.1.1",
         "licensee": "11.1.1",
         "lockfile-lint": "4.14.0",
@@ -3926,6 +3927,29 @@
       "integrity": "sha512-/DCilZlUdz2XyNDF+ASs0PwY+RKG9Y4Silp/gbS72Cvbg4oibc778xcecg+pnNyiNHYgh/TApsiDTjpdniyShw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-check": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.1.0.tgz",
+      "integrity": "sha512-CS4wKJyv6/oq3DbuvaB9i3QqHgFlbs7N+lzBosBFqwm4+Nr1EWBs72rC62lzqSEEtEiQfB3UOvomGAOhjvH02A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -9927,6 +9951,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.14.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "better-npm-audit": "3.11.0",
     "eslint": "9.23.0",
     "eslint-plugin-regexp": "2.7.0",
+    "fast-check": "4.1.0",
     "lcov-total": "2.1.1",
     "licensee": "11.1.1",
     "lockfile-lint": "4.14.0",

--- a/src/result.test.js
+++ b/src/result.test.js
@@ -15,86 +15,116 @@
 import * as assert from "node:assert/strict";
 import { test } from "node:test";
 
+import * as fc from "fast-check";
+
 import { Err, Ok } from "./result.js";
 
 test("result.js", async (t) => {
 	await t.test("Err", async (t) => {
-		const value = "Hello error!";
-
 		await t.test("error", () => {
-			const err = new Err(value);
+			fc.assert(
+				fc.property(fc.anything(), (value) => {
+					const err = new Err(value);
 
-			const got = err.error();
-			const want = value;
-			assert.equal(got, want);
+					const got = err.error();
+					const want = value;
+					assert.equal(got, want);
+				}),
+			);
 		});
 
 		await t.test("isErr", () => {
-			const err = new Err(value);
+			fc.assert(
+				fc.property(fc.anything(), (value) => {
+					const err = new Err(value);
 
-			const got = err.isErr();
-			const want = true;
-			assert.equal(got, want);
+					const got = err.isErr();
+					const want = true;
+					assert.equal(got, want);
+				}),
+			);
 		});
 
 		await t.test("isOk", () => {
-			const err = new Err(value);
+			fc.assert(
+				fc.property(fc.anything(), (value) => {
+					const err = new Err(value);
 
-			const got = err.isOk();
-			const want = false;
-			assert.equal(got, want);
+					const got = err.isOk();
+					const want = false;
+					assert.equal(got, want);
+				}),
+			);
 		});
 
 		await t.test("value", () => {
-			const err = new Err(value);
+			fc.assert(
+				fc.property(fc.anything(), (value) => {
+					const err = new Err(value);
 
-			assert.throws(
-				() => err.value(),
-				{
-					name: "TypeError",
-					message: "Err has no value",
-				},
+					assert.throws(
+						() => err.value(),
+						{
+							name: "TypeError",
+							message: "Err has no value",
+						},
+					);
+				}),
 			);
 		});
 	});
 
 	await t.test("Ok", async (t) => {
-		const value = "Hello value!";
-
 		await t.test("error", () => {
-			const ok = new Ok(value);
+			fc.assert(
+				fc.property(fc.anything(), (value) => {
+					const ok = new Ok(value);
 
-			assert.throws(
-				() => ok.error(),
-				{
-					name: "TypeError",
-					message: "Ok has no error",
-				},
+					assert.throws(
+						() => ok.error(),
+						{
+							name: "TypeError",
+							message: "Ok has no error",
+						},
+					);
+				}),
 			);
 		});
 
 		await t.test("isErr", () => {
-			const ok = new Ok(value);
+			fc.assert(
+				fc.property(fc.anything(), (value) => {
+					const ok = new Ok(value);
 
-			const got = ok.isErr();
-			const want = false;
-			assert.equal(got, want);
+					const got = ok.isErr();
+					const want = false;
+					assert.equal(got, want);
+				}),
+			);
 		});
 
 		await t.test("isOk", () => {
-			const ok = new Ok(value);
+			fc.assert(
+				fc.property(fc.anything(), (value) => {
+					const ok = new Ok(value);
 
-			const got = ok.isOk();
-			const want = true;
-			assert.equal(got, want);
+					const got = ok.isOk();
+					const want = true;
+					assert.equal(got, want);
+				}),
+			);
 		});
 
 		await t.test("value", () => {
-			const ok = new Ok(value);
+			fc.assert(
+				fc.property(fc.anything(), (value) => {
+					const ok = new Ok(value);
 
-			const got = ok.value();
-			const want = value;
-			assert.equal(got, want);
+					const got = ok.value();
+					const want = value;
+					assert.equal(got, want);
+				}),
+			);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Add the package [`fast-check`](https://fast-check.dev/) as a development dependency to be used in testing. In particular, it is a property testing framework that allows for writing, in shorts, tests that verify a property holds for a large variety of inputs. This updates the existing test suite of one file to use property tests, the idea is that new tests are written (when applicable) as property tests and, over time, the existing test suite is enhanced with property tests.