### PR TITLE
Output report even if the outcome is OK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning].
 - Add CLI argument validation and error messaging.
 - Add configuration validation and error messaging.
 - Fix missing output when there are no disallowed deprecation warnings.
+- Fix missing deprecation warnings due to npm output parsing.
 
 ## [0.3.6] - 2025-03-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning].
 
 - Add CLI argument validation and error messaging.
 - Add configuration validation and error messaging.
+- Fix missing output when there are no disallowed deprecation warnings.
 
 ## [0.3.6] - 2025-03-17
 

--- a/src/main.js
+++ b/src/main.js
@@ -74,8 +74,10 @@ try {
 	const unused = reportUnused ? unusedIgnores(config) : [];
 	const { ok, report } = printAndExit(result, unused, { everything }, chalk);
 	if (!ok) {
-		stdout.write(`${report}\n`);
 		exitCode = EXIT_CODE_FAILURE;
+	}
+	if (report) {
+		stdout.write(`${report}\n`);
 	}
 } catch (error) {
 	stderr.write(`error: ${error.message}\n`);

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -51,6 +51,17 @@ test("end-to-end", async (t) => {
 		assert.notEqual(result.exitCode, 2);
 	});
 
+	await t.test("ignoring all deprecation warnings", () => {
+		const result = cli({
+			args: [],
+			project: fixture("ignore-all"),
+		});
+
+		assert.equal(result.exitCode, 0);
+		assert.notEqual(result.stdout, "");
+		assert.equal(result.stderr, "");
+	});
+
 	await t.test("ignoring all deprecation warnings with --errors-only", () => {
 		const result = cli({
 			args: ["--errors-only"],


### PR DESCRIPTION
Fix a bug where the report would not be printed if the outcome of `depreman` is OK (i.e. no unaccounted deprecation warnings). This change is accompanied by an e2e test that ensures this does not regress in the future.

This bug was introduced in #95 as part of a refactoring.