### PR TITLE
Use property testing for `cli.js`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -617,6 +617,7 @@ export default [
 		name: "Tests",
 		files: ["**/*.test.js"],
 		rules: {
+			"guard-for-in": "off",
 			"max-lines-per-function": "off",
 			"max-lines": "off",
 			"no-await-in-loop": "off",


### PR DESCRIPTION
Relates to #127, #140

## Summary

Improve the `cli.js` test suite by using property testing to cover a wider variety of scenarios.