### PR TITLE
Refactor `main.js` to avoid top-level side effects in src/

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,7 @@ import json from "@eslint/json";
 import markdown from "@eslint/markdown";
 import depend from "eslint-plugin-depend";
 import regexp from "eslint-plugin-regexp";
+import top from "@ericcornelissen/eslint-plugin-top";
 import unicorn from "eslint-plugin-unicorn";
 
 export default [
@@ -21,6 +22,7 @@ export default [
 		plugins: {
 			depend,
 			regexp,
+			top,
 			unicorn,
 		},
 		rules: {
@@ -434,6 +436,22 @@ export default [
 				"regexp/use-ignore-case": "error",
 			},
 
+			// eslint-plugin-top
+			...{
+				"top/no-top-level-side-effects": ["error", {
+					allowDerived: false,
+					allowedCalls: [],
+					allowedNews: [],
+					allowFunctionProperties: false,
+					allowIIFE: false,
+					allowPropertyAccess: false,
+				}],
+				"top/no-top-level-variables": ["error", {
+					allowed: ["ObjectExpression"],
+					kind: ["const"],
+				}],
+			},
+
 			// eslint-plugin-unicorn
 			...{
 				"unicorn/better-regex": "error",
@@ -570,11 +588,24 @@ export default [
 		},
 	},
 	{
+		name: "bin",
+		files: ["bin/*.js"],
+		rules: {
+			// eslint-plugin-top
+			"top/no-top-level-side-effects": "off",
+			"top/no-top-level-variables": "off",
+		},
+	},
+	{
 		name: "Scripts",
 		files: ["script/*.js"],
 		rules: {
 			"no-console": "off",
 			"no-await-in-loop": "off",
+
+			// eslint-plugin-top
+			"top/no-top-level-side-effects": "off",
+			"top/no-top-level-variables": "off",
 
 			// eslint-plugin-unicorn
 			"unicorn/no-process-exit": "off",
@@ -591,6 +622,10 @@ export default [
 			"no-shadow": ["error", {
 				allow: ["t"],
 			}],
+
+			// eslint-plugin-top
+			"top/no-top-level-side-effects": "off",
+			"top/no-top-level-variables": "off",
 		},
 	},
 	{

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,3 +1,8 @@
 #!/usr/bin/env node
 
-import "../src/main.js";
+import { argv, exit } from "node:process";
+
+import { cli } from "../src/main.js";
+
+const exitCode = await cli(argv);
+exit(exitCode);

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "depreman": "bin/cli.js"
       },
       "devDependencies": {
+        "@ericcornelissen/eslint-plugin-top": "3.5.1",
         "@eslint/json": "0.10.0",
         "@eslint/markdown": "6.4.0",
         "@stryker-mutator/core": "8.7.1",
@@ -635,6 +636,19 @@
       "integrity": "sha512-xW5Xb9Fr3WtYAOwavxxWL0CaJK/ReT+HKb5/R6dR1p9RVJ55MTdaxPdeTKY2ukhFchv2YHPMM8YuZyfyLqxedg==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/@ericcornelissen/eslint-plugin-top": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@ericcornelissen/eslint-plugin-top/-/eslint-plugin-top-3.5.1.tgz",
+      "integrity": "sha512-3WRqNLIMFEUJoKfh/Nj2Ggq7RwxASI5ut307hGcmzt2Gu+xoppW1f3OinhQ+AAPKJmFm3Yp23tOifOhBbkw8iA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "18.x || 20.x || 22.x"
+      },
+      "peerDependencies": {
+        "eslint": "8.x || 9.x"
+      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.6.1",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "semver": "^7.0.0"
   },
   "devDependencies": {
+    "@ericcornelissen/eslint-plugin-top": "3.5.1",
     "@eslint/json": "0.10.0",
     "@eslint/markdown": "6.4.0",
     "@stryker-mutator/core": "8.7.1",

--- a/src/ignores.js
+++ b/src/ignores.js
@@ -15,7 +15,7 @@
 import * as date from "./date.js";
 import * as semver from "./semver.js";
 
-const kUsed = Symbol.for("#used");
+const kUsed = Symbol.for("#used"); // eslint-disable-line top/no-top-level-side-effects
 const kIgnore = "#ignore";
 const kExpire = "#expire";
 


### PR DESCRIPTION
Relates to #64

## Summary

This refactors the `main.js` module in order to avoid having side effects at the top level in the `src/` directory. This aids in the testability of the source code.

The use of top-level side effects is now guarded by a newly introduced ESLint plugin - [`@ericcornelissen/eslint-plugin-top`](https://www.npmjs.com/package/@ericcornelissen/eslint-plugin-top) - which is used to ban all top level side effects and limit top level variables.