### PR TITLE
Refactor CLI flags arbitrary to be shrinkable

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -142,7 +142,7 @@ export default [
 				"no-object-constructor": "error",
 				"no-octal-escape": "error",
 				"no-octal": "error",
-				"no-param-reassign": "error",
+				"no-param-reassign": "off",
 				"no-plusplus": "error",
 				"no-promise-executor-return": "error",
 				"no-proto": "error",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "mutation": "stryker run .stryker.js",
     "test": "npm run test:unit && npm run test:e2e",
     "test:unit": "node --test 'src/*.test.js'",
+    "test:watch": "node --test --watch 'src/*.test.js'",
     "test:e2e": "node --test 'test/e2e.test.js'",
     "verify": "npm run check && npm run coverage"
   },


### PR DESCRIPTION
Relates to #161

## Summary

Improve the arbitrary flag generation helpeer for the CLI to be constructive (rather than using `.chain`) to help shrinking. Also make sure not to mutate the arguments of `.map` because that can lead fast-check to get in an infinite loop. Both of these help debugging test failures and (more pressing) speeds up mutation testing because with the old code many mutants in `cli.js` would be caught due to timeouts instead of test failures.
