### PR TITLE
Refactor `deprecations.js` and improve its test suite

### DIFF
--- a/.stryker.js
+++ b/.stryker.js
@@ -27,8 +27,8 @@ export default {
 
 	thresholds: {
 		high: 100,
-		low: 96,
-		break: 96,
+		low: 100,
+		break: 100,
 	},
 
 	tempDirName: "node_modules/.temp/stryker",


### PR DESCRIPTION
Relates to #61, #85, #138

## Summary

Use the mutation testing results(/mutants) in an effort to refactor the `deprecations.js` module for clarity and testability and improve the test suite with meaningful scenarios.