### PR TITLE
Lint JSDoc

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,7 @@ import * as process from "node:process";
 import json from "@eslint/json";
 import markdown from "@eslint/markdown";
 import depend from "eslint-plugin-depend";
+import jsdoc from "eslint-plugin-jsdoc";
 import regexp from "eslint-plugin-regexp";
 import top from "@ericcornelissen/eslint-plugin-top";
 import unicorn from "eslint-plugin-unicorn";
@@ -23,6 +24,7 @@ export default [
 		},
 		plugins: {
 			depend,
+			jsdoc,
 			regexp,
 			top,
 			unicorn,
@@ -244,6 +246,168 @@ export default [
 				"depend/ban-dependencies": ["error", {
 					"allowed": ["eslint-plugin-unicorn"],
 				}],
+			},
+
+			// eslint-plugin-jsdoc
+			...{
+				"jsdoc/check-access": "error",
+				"jsdoc/check-alignment": "error",
+				"jsdoc/check-indentation": [
+					"error",
+					{
+						excludeTags: [
+							"typedef",
+						],
+					},
+				],
+				"jsdoc/check-line-alignment": ["error", "never"],
+				"jsdoc/check-param-names": [
+					"error",
+					{
+						allowExtraTrailingParamDocs: false,
+						checkDestructured: true,
+						checkRestProperty: true,
+						disableExtraPropertyReporting: false,
+						enableFixer: false,
+						useDefaultObjectProperties: true,
+					},
+				],
+				"jsdoc/check-property-names": "error",
+				"jsdoc/check-syntax": "error",
+				"jsdoc/check-tag-names": "error",
+				"jsdoc/check-types": [
+					"error",
+					{
+						exemptTagContexts: [],
+						noDefaults: false,
+						unifyParentAndChildTypeChecks: false,
+					},
+				],
+				"jsdoc/empty-tags": "error",
+				"jsdoc/implements-on-classes": "error",
+				"jsdoc/informative-docs": "error",
+				"jsdoc/match-description": [
+					"error",
+					{
+						mainDescription: "^$",
+						tags: {
+							param: "^$",
+							returns: "^$",
+							throws: "^$",
+							yields: "^$",
+						},
+					},
+				],
+				"jsdoc/match-name": "off",
+				"jsdoc/multiline-blocks": [
+					"error",
+					{
+						noFinalLineText: true,
+						noMultilineBlocks: false,
+						noSingleLineBlocks: false,
+						noZeroLineText: true,
+						singleLineTags: [],
+					},
+				],
+				"jsdoc/no-bad-blocks": [
+					"error",
+					{
+						ignore: [],
+						preventAllMultiAsteriskBlocks: true,
+					},
+				],
+				"jsdoc/no-blank-block-descriptions": "error",
+				"jsdoc/no-defaults": "error",
+				"jsdoc/no-missing-syntax": "off",
+				"jsdoc/no-multi-asterisks": [
+					"error",
+					{
+						allowWhitespace: true,
+						preventAtEnd: true,
+						preventAtMiddleLines: true,
+					},
+				],
+				"jsdoc/no-restricted-syntax": "off",
+				"jsdoc/no-types": "off",
+				"jsdoc/no-undefined-types": "error",
+				"jsdoc/require-asterisk-prefix": ["error", "always"],
+				"jsdoc/require-description-complete-sentence": "off",
+				"jsdoc/require-description": "off",
+				"jsdoc/require-example": "off",
+				"jsdoc/require-file-overview": "off",
+				"jsdoc/require-hyphen-before-param-description": "off",
+				"jsdoc/require-jsdoc": [
+					"error",
+					{
+						publicOnly: false,
+						require: {
+							ArrowFunctionExpression: false,
+							ClassDeclaration: false,
+							ClassExpression: false,
+							FunctionDeclaration: true,
+							FunctionExpression: false,
+							MethodDefinition: true,
+						},
+					},
+				],
+				"jsdoc/require-param": "error",
+				"jsdoc/require-param-description": "off",
+				"jsdoc/require-param-name": "error",
+				"jsdoc/require-param-type": "error",
+				"jsdoc/require-property": "error",
+				"jsdoc/require-property-description": "off",
+				"jsdoc/require-property-name": "error",
+				"jsdoc/require-property-type": "error",
+				"jsdoc/require-returns": [
+					"error",
+					{
+						checkConstructors: false,
+						checkGetters: true,
+						exemptedBy: [],
+						forceRequireReturn: true,
+						forceReturnsWithAsync: true,
+					},
+				],
+				"jsdoc/require-returns-check": [
+					"error",
+					{
+						exemptGenerators: true,
+						exemptAsync: false,
+						reportMissingReturnForUndefinedTypes: false,
+					},
+				],
+				"jsdoc/require-returns-description": "off",
+				"jsdoc/require-returns-type": "error",
+				"jsdoc/require-throws": "error",
+				"jsdoc/require-yields": [
+					"error",
+					{
+						exemptedBy: [],
+						forceRequireNext: false,
+						forceRequireYields: true,
+						next: false,
+						nextWithGeneratorTag: false,
+						withGeneratorTag: false,
+					},
+				],
+				"jsdoc/require-yields-check": [
+					"error",
+					{
+						checkGeneratorsOnly: false,
+						next: false,
+					},
+				],
+				"jsdoc/sort-tags": "error",
+				"jsdoc/tag-lines": [
+					"error",
+					"any",
+					{
+						endLines: 0,
+						startLines: 1,
+					},
+				],
+				"jsdoc/text-escaping": "off",
+				"jsdoc/valid-types": "error",
 			},
 
 			// eslint-plugin-regexp
@@ -608,6 +772,9 @@ export default [
 			"no-console": "off",
 			"no-await-in-loop": "off",
 
+			// eslint-plugin-jsdoc
+			"jsdoc/require-jsdoc": "off",
+
 			// eslint-plugin-top
 			"top/no-top-level-side-effects": "off",
 			"top/no-top-level-variables": "off",
@@ -628,6 +795,10 @@ export default [
 			"no-shadow": ["error", {
 				allow: ["t"],
 			}],
+
+			// eslint-plugin-jsdoc
+			"jsdoc/require-jsdoc": "off",
+			"jsdoc/require-returns": "off",
 
 			// eslint-plugin-top
 			"top/no-top-level-side-effects": "off",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "better-npm-audit": "3.11.0",
         "eslint": "9.29.0",
         "eslint-plugin-depend": "1.1.0",
+        "eslint-plugin-jsdoc": "51.2.3",
         "eslint-plugin-regexp": "2.9.0",
         "eslint-plugin-unicorn": "59.0.0",
         "fast-check": "4.1.0",
@@ -600,6 +601,23 @@
       },
       "peerDependencies": {
         "eslint": "8.x || 9.x"
+      }
+    },
+    "node_modules/@es-joy/jsdoccomment": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.52.0.tgz",
+      "integrity": "sha512-BXuN7BII+8AyNtn57euU2Yxo9yA/KUDNzrpXyi3pfqKmBhhysR6ZWOebFh3vyPoqA3/j1SOvGgucElMGwlXing==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.8",
+        "@typescript-eslint/types": "^8.34.1",
+        "comment-parser": "1.4.1",
+        "esquery": "^1.6.0",
+        "jsdoc-type-pratt-parser": "~4.1.0"
+      },
+      "engines": {
+        "node": ">=20.11.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1536,9 +1554,9 @@
       }
     },
     "node_modules/@npmcli/arborist/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1562,9 +1580,9 @@
       }
     },
     "node_modules/@npmcli/fs/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1596,9 +1614,9 @@
       }
     },
     "node_modules/@npmcli/git/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1698,9 +1716,9 @@
       }
     },
     "node_modules/@npmcli/metavuln-calculator/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1765,9 +1783,9 @@
       }
     },
     "node_modules/@npmcli/package-json/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -2058,9 +2076,9 @@
       }
     },
     "node_modules/@stryker-mutator/core/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -2194,9 +2212,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
     },
@@ -2230,6 +2248,20 @@
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.35.0.tgz",
+      "integrity": "sha512-0mYH3emanku0vHw2aRLNGqe7EXh9WHEhi7kZzscrMDf6IIRUQ5Jk4wp1QrledE/36KtdZrVfKnE32eZCf/vaVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
     "node_modules/@yarnpkg/parsers": {
       "version": "3.0.2",
@@ -2424,6 +2456,16 @@
       "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/are-docs-informative": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/are-we-there-yet": {
       "version": "4.0.2",
@@ -2631,9 +2673,9 @@
       }
     },
     "node_modules/better-npm-audit/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3310,9 +3352,9 @@
       "license": "MIT"
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3778,9 +3820,47 @@
       }
     },
     "node_modules/eslint-plugin-depend/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "51.2.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-51.2.3.tgz",
+      "integrity": "sha512-pagzxFubOih+O6XSB1D8BkDkJjF4G4/v8s9pRg4FkXQJLu0e3QJg621ayhmnhyc5mNBpp3cYCNiUyeLQs7oz7w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.52.0",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.4.1",
+        "debug": "^4.4.1",
+        "escape-string-regexp": "^4.0.0",
+        "espree": "^10.4.0",
+        "esquery": "^1.6.0",
+        "parse-imports-exports": "^0.2.4",
+        "semver": "^7.7.2",
+        "spdx-expression-parse": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.11.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3874,9 +3954,9 @@
       }
     },
     "node_modules/eslint-plugin-unicorn/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -5524,9 +5604,9 @@
       }
     },
     "node_modules/get-dep-tree/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -6901,9 +6981,9 @@
       }
     },
     "node_modules/licensee/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -8008,9 +8088,9 @@
       }
     },
     "node_modules/ls-engines/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -9455,9 +9535,9 @@
       }
     },
     "node_modules/node-gyp/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -9520,9 +9600,9 @@
       }
     },
     "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -9546,9 +9626,9 @@
       }
     },
     "node_modules/npm-install-checks/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -9582,9 +9662,9 @@
       }
     },
     "node_modules/npm-package-arg/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -9621,9 +9701,9 @@
       }
     },
     "node_modules/npm-pick-manifest/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -10006,6 +10086,16 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/parse-imports-exports": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/parse-imports-exports/-/parse-imports-exports-0.2.4.tgz",
+      "integrity": "sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-statements": "1.0.11"
+      }
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -10044,6 +10134,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/parse-statements": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
+      "integrity": "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -10494,9 +10591,9 @@
       }
     },
     "node_modules/read-package-json/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "better-npm-audit": "3.11.0",
     "eslint": "9.29.0",
     "eslint-plugin-depend": "1.1.0",
+    "eslint-plugin-jsdoc": "51.2.3",
     "eslint-plugin-regexp": "2.9.0",
     "eslint-plugin-unicorn": "59.0.0",
     "fast-check": "4.1.0",

--- a/src/config.js
+++ b/src/config.js
@@ -40,10 +40,8 @@ export async function getConfiguration(fs) {
 }
 
 /**
- * @param {Object} p
- * @param {string} p.file
- * @param {FileSystem} p.fs
- * @returns {Result<Config, string>}
+ * @param {string} raw
+ * @returns {Result<object, string>}
  */
 function parseRawConfig(raw) {
 	try {
@@ -56,6 +54,7 @@ function parseRawConfig(raw) {
 
 /**
  * @param {Config} config
+ * @param {boolean} root
  * @returns {Option<string[]>}
  */
 function validateConfig(config, root=true) {
@@ -107,7 +106,7 @@ function validateConfig(config, root=true) {
 
 /**
  * @param {any} value
- * @return {string}
+ * @returns {string}
  */
 function typeOf(value) {
 	if (value === null) {

--- a/src/cp.js
+++ b/src/cp.js
@@ -14,9 +14,6 @@
 
 import { Err, Ok } from "./result.js";
 
-/**
- * @type {ExecCP}
- */
 export class CP {
 	/**
 	 * @type {cp}
@@ -61,9 +58,13 @@ export class CP {
 /**
  * @typedef ExecCP
  * @property {Exec} exec
- *
+ */
+
+/**
  * @typedef {function(string, string[]): Promise<Result<Output, Output>>} Exec
- *
+ */
+
+/**
  * @typedef Output
  * @property {string} stderr
  * @property {string} stdout
@@ -71,18 +72,8 @@ export class CP {
 
 /**
  * @typedef cp
- * @property {function(string, execCallback)} exec
- * @property {function(Error, string, string)} execCallback
- *
- * @typedef options
- * @property {boolean} shell
- *
- * @typedef process
- * @property {function(string, function(number, string): null)} on
- * @property {stream} stdout
- *
- * @typedef stream
- * @property {function(string, function(Buffer): null)} on
+ * @property {function(string, execCallback): void} exec
+ * @property {function(Error, string, string): void} execCallback
  */
 
 /**

--- a/src/cp.mock.js
+++ b/src/cp.mock.js
@@ -16,12 +16,9 @@ import { mock } from "node:test";
 
 import { Err, Ok } from "./result.js";
 
-/**
- * @type {ExecCP}
- */
 export class CP {
 	/**
-	 * @param {Object<string, MockCommand>} commands
+	 * @param {{[key: string]: MockCommand}} commands
 	 */
 	constructor(commands) {
 		this.exec = mock.fn((cmd, args) => {

--- a/src/date.js
+++ b/src/date.js
@@ -106,12 +106,6 @@ const MIN_MONTH = 1, MAX_MONTH = 12;
 const MIN_DAY = 1, MAX_DAY = 31;
 
 /**
- * Determine if a raw (unverified) date is a valid date.
- *
- * The year is validated in a way to catch likely mistakes for the purposes of
- * an expiry date (e.g. a year past 10.000 is probably not intended as an expiry
- * date). The day is validated approximately, not considering the month.
- *
  * @param {RawDate} date
  * @returns {boolean}
  */

--- a/src/deprecations.js
+++ b/src/deprecations.js
@@ -78,15 +78,21 @@ function findPackagePaths(pkg, hierarchy, aliases, path = []) {
 
 /**
  * @typedef {Package & _Deprecation} DeprecatedPackage
- *
+ */
+
+/**
  * @typedef _Deprecation
  * @property {PackagePath[]} paths
  * @property {string} reason
- *
+ */
+
+/**
  * @typedef Package
  * @property {string} name
  * @property {string} version
- *
+ */
+
+/**
  * @typedef {Package[]} PackagePath
  */
 
@@ -95,4 +101,12 @@ function findPackagePaths(pkg, hierarchy, aliases, path = []) {
  * @property {function(): Promise<Result<Aliases, string>>} aliases
  * @property {function(): Promise<Result<DeprecatedPackage[], string>>} deprecations
  * @property {function(): Promise<Result<PackageHierarchy, string>>} hierarchy
+ */
+
+/** @typedef {import("./npm.js").Aliases} Aliases */
+/** @typedef {import("./npm.js").PackageHierarchy} PackageHierarchy */
+
+/**
+ * @template O, E
+ * @typedef {import("./result.js").Result<O, E>} Result
  */

--- a/src/deprecations.test.js
+++ b/src/deprecations.test.js
@@ -293,7 +293,7 @@ test("deprecations.js", (t) => {
 
 class PM {
 	/**
-	 * @param {Object} p
+	 * @param {object} p
 	 * @param {import("./npm.js").Aliases} p.aliases
 	 * @param {import("./npm.js").DeprecatedPackage} p.deprecations
 	 * @param {import("./npm.js").PackageHierarchy} p.hierarchy

--- a/src/fs.js
+++ b/src/fs.js
@@ -14,9 +14,6 @@
 
 import { Err, Ok } from "./result.js";
 
-/**
- * @type {ReadFS}
- */
 export class FS {
 	/**
 	 * @type {fs}
@@ -32,7 +29,7 @@ export class FS {
 
 	/**
 	 * @param {string} filepath
-	 * @return {Promise<boolean>}
+	 * @returns {Promise<boolean>}
 	 */
 	async access(filepath) {
 		try {
@@ -45,7 +42,7 @@ export class FS {
 
 	/**
 	 * @param {string} filepath
-	 * @return {Promise<Result<string, string>>}
+	 * @returns {Promise<Result<string, string>>}
 	 */
 	async readFile(filepath) {
 		const options = { encoding: "utf8" };

--- a/src/fs.mock.js
+++ b/src/fs.mock.js
@@ -16,12 +16,9 @@ import { mock } from "node:test";
 
 import { Err, Ok } from "./result.js";
 
-/**
- * @type {ReadFS}
- */
 export class FS {
 	/**
-	 * @param {Object<string, string>} files
+	 * @param {{[key: string]: string}} files
 	 */
 	constructor(files) {
 		this.access = mock.fn((path) => {

--- a/src/ignores.js
+++ b/src/ignores.js
@@ -187,6 +187,7 @@ function isExpired(config) {
 /**
  * @param {string} pkg
  * @returns {[string, string]}
+ * @throws {Error}
  */
 function parseRule(pkg) {
 	const i = pkg.lastIndexOf("@");

--- a/src/main.js
+++ b/src/main.js
@@ -31,6 +31,9 @@ const EXIT_CODE_SUCCESS = 0;
 const EXIT_CODE_FAILURE = 1;
 const EXIT_CODE_UNEXPECTED = 2;
 
+/**
+ * @returns {void}
+ */
 function help() {
 	stdout.write(`depreman [-h|--help] [--errors-only] [--report-unused]
          [--omit=<dev|optional|peer> ...]
@@ -51,7 +54,7 @@ to ignore npm deprecation warnings for your dependencies.
 
 /**
  * @param {Options} options
- * @return {Promise<ExitCode>}
+ * @returns {Promise<ExitCode>}
  */
 async function depreman(options) {
 	try {
@@ -80,7 +83,7 @@ async function depreman(options) {
 
 /**
  * @param {string[]} argv
- * @return {Promise<ExitCode>}
+ * @returns {Promise<ExitCode>}
  */
 export async function cli(argv) {
 	const options = parseArgv(argv);

--- a/src/npm.js
+++ b/src/npm.js
@@ -32,7 +32,7 @@ export class NPM {
 	#options;
 
 	/**
-	 * @param {Object} p
+	 * @param {object} p
 	 * @param {ExecCP} p.cp
 	 * @param {ReadFS} p.fs
 	 * @param {Options} p.options
@@ -165,7 +165,7 @@ export class NPM {
 	}
 
 	/**
-   * @returns {Promise<boolean>}
+	 * @returns {Promise<boolean>}
 	 */
 	async #hasLockfile() {
 		return await this.#fs.access("./package-lock.json");
@@ -216,23 +216,33 @@ function parseJSON(rawJSON) {
 
 /**
  * @typedef {Map<string, Package>} Aliases
- *
+ */
+
+/**
  * @typedef Deprecation
  * @property {string} reason
- *
+ */
+
+/**
  * @typedef {Package & Deprecation} DeprecatedPackage
- *
+ */
+
+/**
  * @typedef Package
  * @property {string} name
  * @property {string} version
- *
+ */
+
+/**
  * @typedef PackageHierarchy
- * @property {Object<string, HierarchyDependency>} dependencies
+ * @property {{[key: string]: HierarchyDependency}} dependencies
  * @property {string} name
  * @property {string} version
- *
+ */
+
+/**
  * @typedef HierarchyDependency
- * @property {Object<string, HierarchyDependency>} dependencies
+ * @property {{[key: string]: HierarchyDependency}} dependencies
  * @property {string} version
  */
 

--- a/src/option.js
+++ b/src/option.js
@@ -14,14 +14,13 @@
 
 /**
  * @template T
- * @typedef Option<T>
+ * @typedef Option
  * @property {function(): boolean} isNone
  * @property {function(): boolean} isSome
  * @property {function(): T} value
  */
 
 /**
- * @class
  * @template T
  */
 export class Some {
@@ -73,6 +72,7 @@ export const None = {
 	},
 
 	/**
+	 * @returns {never}
 	 * @throws {TypeError}
 	 */
 	value() {

--- a/src/output.js
+++ b/src/output.js
@@ -82,9 +82,9 @@ function pkgToString(pkg) {
 	return `${pkg.name}@${pkg.version}`;
 }
 
-/** @typedef {Iterable<Result>} Results */
+/** @typedef {Result[]} Results */
 
-/**  @typedef {Iterable<string[]>} Unused */
+/** @typedef {string[][]} Unused */
 
 /**
  * @typedef Package
@@ -97,7 +97,9 @@ function pkgToString(pkg) {
  * @property {string} reason The deprecation message.
  * @property {{ path: Package[] }[]} kept
  * @property {{ path: Package[], reason: string | boolean }[]} ignored
- *
+ */
+
+/**
  * @typedef {Package & _Result} Result
  */
 

--- a/src/result.js
+++ b/src/result.js
@@ -14,7 +14,7 @@
 
 /**
  * @template O, E
- * @typedef Result<O, E>
+ * @typedef Result
  * @property {function(): E} error
  * @property {function(): boolean} isErr
  * @property {function(): boolean} isOk
@@ -22,7 +22,6 @@
  */
 
 /**
- * @class
  * @template T
  */
 export class Ok {
@@ -34,6 +33,7 @@ export class Ok {
 	}
 
 	/**
+	 * @returns {never}
 	 * @throws {TypeError}
 	 */
 	error() {
@@ -63,7 +63,6 @@ export class Ok {
 }
 
 /**
- * @class
  * @template T
  */
 export class Err {
@@ -96,6 +95,7 @@ export class Err {
 	}
 
 	/**
+	 * @returns {never}
 	 * @throws {TypeError}
 	 */
 	value() {


### PR DESCRIPTION
Relates to #64

## Summary

Enable JSDoc linting with [`eslint-plugin-jsdoc`](https://www.npmjs.com/package/eslint-plugin-jsdoc). Configure it fully explicitly in the ESLint configuration file. Update the code base according to detected violations.