### PR TITLE
Add support for `yarn`

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ The CLI has a couple of options:
 - `--report-unused`: report and fail if there is an ignore directive that is
   unused. This is recommended if you have a lockfile but discouraged if you do
   not.
+- `--package-manager=<npm|yarn>`: select which package manager to use, 'npm'
+  (default) or 'yarn'.
 - `--omit=<dev|optional|peer>`: ignore deprecation warnings in development,
   optional, or peer dependencies. Can be repeated.
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -41,6 +41,7 @@ function parse(argv) {
 		omitDev: removeFromList(argv, "--omit=dev"),
 		omitOptional: removeFromList(argv, "--omit=optional"),
 		omitPeer: removeFromList(argv, "--omit=peer"),
+		packageManager: packageManager(argv),
 		reportUnused: removeFromList(argv, "--report-unused"),
 	};
 
@@ -80,12 +81,29 @@ function removeFromList(haystack, needle) {
 }
 
 /**
+ * @param {string[]} argv
+ * @returns {string}
+ */
+function packageManager(argv) {
+	if (removeFromList(argv, "--package-manager=yarn")) {
+		return "yarn"
+	}
+
+	if (removeFromList(argv, "--package-manager=npm")) {
+		return "npm";
+	}
+
+	return "npm";
+}
+
+/**
  * @typedef Config
  * @property {boolean} help
  * @property {boolean} everything
  * @property {boolean} omitDev
  * @property {boolean} omitOptional
  * @property {boolean} omitPeer
+ * @property {"npm" | "yarn"} packageManager
  * @property {boolean} reportUnused
  */
 

--- a/src/main.js
+++ b/src/main.js
@@ -25,6 +25,7 @@ import { getDeprecatedPackages } from "./deprecations.js";
 import { FS } from "./fs.js";
 import { removeIgnored, unusedIgnores } from "./ignores.js";
 import { NPM } from "./npm.js";
+import { Yarn } from "./yarn.js";
 import { printAndExit } from "./output.js";
 
 const EXIT_CODE_SUCCESS = 0;
@@ -36,10 +37,10 @@ const EXIT_CODE_UNEXPECTED = 2;
  */
 function help() {
 	stdout.write(`depreman [-h|--help] [--errors-only] [--report-unused]
-         [--omit=<dev|optional|peer> ...]
+         [--omit=<dev|optional|peer> ...] [--package-manager=<npm|yarn>]
 
-Manage npm deprecation.  Create an '.ndmrc' file with a JSON-based configuration
-to ignore npm deprecation warnings for your dependencies.
+Manage deprecation warnings. Create an '.ndmrc' file with a JSON-based config
+to ignore deprecation warnings for your dependencies.
 
    -h, --help
       Show this help message.
@@ -47,6 +48,8 @@ to ignore npm deprecation warnings for your dependencies.
       Only output deprecation warnings that are not ignored.
    --omit=<dev|optional|peer>
       Omit deprecation warnings for development, optional, or peer dependencies.
+   --package-manager=<npm|yarn>
+      Which package manager to use, 'npm' (default) or 'yarn'.
    --report-unused
       Report and fail for unused ignore directives.
 
@@ -63,7 +66,9 @@ async function depreman(options) {
 	try {
 		const cp = new CP(nodeCp);
 		const fs = new FS(nodeFs);
-		const pm = new NPM({ cp, fs, options });
+		const pm = options.packageManager === "yarn"
+			? new Yarn({ cp, options })
+			: new NPM({ cp, fs, options });
 
 		const [config, deprecations] = await Promise.all([
 			getConfiguration(fs),

--- a/src/yarn.js
+++ b/src/yarn.js
@@ -1,0 +1,75 @@
+// Copyright (C) 2025  Eric Cornelissen
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, version 3 of the License only.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Err } from "./result.js";
+
+export class Yarn {
+	/**
+	 * @returns {Promise<Result<Aliases, string>>}
+	 */
+	aliases() {
+		return new Err("not implemented");
+	}
+
+	/**
+	 * @returns {Promise<Result<DeprecatedPackage[], string>>}
+	 */
+	deprecations() {
+		return new Err("not implemented");
+	}
+
+	/**
+	 * @returns {Promise<Result<PackageHierarchy, string>>}
+	 */
+	hierarchy() {
+		return new Err("not implemented");
+	}
+}
+
+/**
+ * @typedef {Map<string, Package>} Aliases
+ */
+
+/**
+ * @typedef Deprecation
+ * @property {string} reason
+ */
+
+/**
+ * @typedef {Package & Deprecation} DeprecatedPackage
+ */
+
+/**
+ * @typedef Package
+ * @property {string} name
+ * @property {string} version
+ */
+
+/**
+ * @typedef PackageHierarchy
+ * @property {{[key: string]: HierarchyDependency}} dependencies
+ * @property {string} name
+ * @property {string} version
+ */
+
+/**
+ * @typedef HierarchyDependency
+ * @property {{[key: string]: HierarchyDependency}} dependencies
+ * @property {string} version
+ */
+
+/**
+ * @template O, E
+ * @typedef {import("./result.js").Result<O, E>} Result
+ */


### PR DESCRIPTION
Closes #92
Relates to #91

## Summary

Add logic to support multiple package managers and `(TODO:)` implement the package manager interface for `yarn` such that it is supported by depreman.