### PR TITLE
Implement `--version` flag

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -9,13 +9,13 @@ body:
         Before you submit your report, make sure the bug has not already been
         reported. Also check for closed bug reports, e.g. in case it has been
         fixed in a new version.
-  - type: input
+  - type: textarea
     id: version
     attributes:
       label: Version
       description: |
-        What version are you using? You can use `npm ls depreman` for this.
-      placeholder: ex. v0.3.9
+        Enter the output of `depreman --version` (or `npm ls depreman` as
+        fallback).
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -8,13 +8,13 @@ body:
       value: |
         Before you submit your request, check that it has not already been
         requested.
-  - type: input
+  - type: textarea
     id: version
     attributes:
       label: Version
       description: |
-        What version are you using? You can use `npm ls depreman` for this.
-      placeholder: ex. v0.3.9
+        Enter the output of `depreman --version` (or `npm ls depreman` as
+        fallback).
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -10,13 +10,13 @@ body:
 
         You can also use this form if you're unsure if you found a bug or if a
         feature is missing.
-  - type: input
+  - type: textarea
     id: version
     attributes:
       label: Version
       description: |
-        What version are you using? You can use `npm ls depreman` for this.
-      placeholder: ex. v0.3.9
+        Enter the output of `depreman --version` (or `npm ls depreman` as
+        fallback).
     validations:
       required: true
   - type: textarea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning].
 
 ## Unreleased
 
+- Add `--version` flag.
 - Fix alias resolution for `optionalDependencies` and `peerDependencies`.
 
 ## 0.3.11 (2025-09-17)

--- a/src/cli.js
+++ b/src/cli.js
@@ -43,6 +43,7 @@ function parse(argv) {
 		omitPeer: removeFromList(argv, "--omit=peer"),
 		packageManager: packageManager(argv),
 		reportUnused: removeFromList(argv, "--report-unused"),
+		version: removeFromList(argv, "--version"),
 	};
 
 	return [config, argv];
@@ -102,6 +103,7 @@ function packageManager(argv) {
  * @property {boolean} omitPeer
  * @property {"npm" | "yarn"} packageManager
  * @property {boolean} reportUnused
+ * @property {boolean} version
  */
 
 /**

--- a/src/cli.test.js
+++ b/src/cli.test.js
@@ -31,6 +31,7 @@ test("cli.js", (t) => {
 		"--package-manager=npm",
 		"--package-manager=yarn",
 		"--report-unused",
+		"--version",
 	];
 
 	const arbitrary = {
@@ -289,6 +290,20 @@ test("cli.js", (t) => {
 						const got = parseArgv(argv);
 						assert.ok(got.isOk());
 						assert.ok(got.value().reportUnused);
+					},
+				),
+			);
+		});
+
+		t.test("--version", () => {
+			fc.assert(
+				fc.property(
+					arbitrary.flags({ include: ["--version"] }),
+					(args) => {
+						const argv = [...base, ...args];
+						const got = parseArgv(argv);
+						assert.ok(got.isOk());
+						assert.ok(got.value().version);
 					},
 				),
 			);

--- a/src/main.js
+++ b/src/main.js
@@ -34,29 +34,26 @@ const EXIT_CODE_FAILURE = 1;
 const EXIT_CODE_UNEXPECTED = 2;
 
 /**
- * @returns {void}
+ * @param {string[]} argv
+ * @returns {Promise<ExitCode>}
  */
-function help() {
-	stdout.write(`depreman [-h|--help] [--version] [--errors-only] [--report-unused]
-         [--omit=<dev|optional|peer> ...] [--package-manager=<npm|yarn>]
+export async function cli(argv) {
+	const options = parseArgv(argv);
+	if (options.isErr()) {
+		stderr.write(`${options.error()}\n`);
+		return EXIT_CODE_UNEXPECTED;
+	}
 
-Manage deprecation warnings. Create an '.ndmrc' file with a JSON-based config
-to ignore deprecation warnings for your dependencies.
+	if (options.value().help) {
+		help();
+		return EXIT_CODE_SUCCESS;
+	}
 
-   -h, --help
-      Show this help message.
-   --errors-only
-      Only output deprecation warnings that are not ignored.
-   --omit=<dev|optional|peer>
-      Omit deprecation warnings for development, optional, or peer dependencies.
-   --package-manager=<npm|yarn>
-      Which package manager to use, 'npm' (default) or 'yarn'.
-   --report-unused
-      Report and fail for unused ignore directives.
+	if (options.value().version) {
+		return await versions();
+	}
 
-Need more help? Found a bug? Missing something? See:
-https://github.com/ericcornelissen/depreman/issues/new/choose
-`);
+	return await depreman(options.value());
 }
 
 /**
@@ -95,26 +92,29 @@ async function depreman(options) {
 }
 
 /**
- * @param {string[]} argv
- * @returns {Promise<ExitCode>}
+ * @returns {void}
  */
-export async function cli(argv) {
-	const options = parseArgv(argv);
-	if (options.isErr()) {
-		stderr.write(`${options.error()}\n`);
-		return EXIT_CODE_UNEXPECTED;
-	}
+function help() {
+	stdout.write(`depreman [-h|--help] [--version] [--errors-only] [--report-unused]
+         [--omit=<dev|optional|peer> ...] [--package-manager=<npm|yarn>]
 
-	if (options.value().help) {
-		help();
-		return EXIT_CODE_SUCCESS;
-	}
+Manage deprecation warnings. Create an '.ndmrc' file with a JSON-based config
+to ignore deprecation warnings for your dependencies.
 
-	if (options.value().version) {
-		return await versions();
-	}
+   -h, --help
+      Show this help message.
+   --errors-only
+      Only output deprecation warnings that are not ignored.
+   --omit=<dev|optional|peer>
+      Omit deprecation warnings for development, optional, or peer dependencies.
+   --package-manager=<npm|yarn>
+      Which package manager to use, 'npm' (default) or 'yarn'.
+   --report-unused
+      Report and fail for unused ignore directives.
 
-	return await depreman(options.value());
+Need more help? Found a bug? Missing something? See:
+https://github.com/ericcornelissen/depreman/issues/new/choose
+`);
 }
 
 /**

--- a/src/option.js
+++ b/src/option.js
@@ -13,10 +13,11 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
- * @template T
+ * @template T, O
  * @typedef Option
  * @property {function(): boolean} isNone
  * @property {function(): boolean} isSome
+ * @property {function(Option<O>): T | O} or
  * @property {function(): T} value
  */
 
@@ -50,6 +51,13 @@ export class Some {
 	/**
 	 * @returns {T}
 	 */
+	or() {
+		return this;
+	}
+
+	/**
+	 * @returns {T}
+	 */
 	value() {
 		return this.#value;
 	}
@@ -71,6 +79,15 @@ export const None = {
 	 */
 	isSome() {
 		return false;
+	},
+
+	/**
+	 * @template T
+	 * @param {Option<T>} other
+	 * @returns {T}
+	 */
+	or(other) {
+		return other;
 	},
 
 	/**

--- a/src/option.test.js
+++ b/src/option.test.js
@@ -33,6 +33,26 @@ test("option.js", (t) => {
 			assert.equal(got, want);
 		});
 
+		t.test("or", () => {
+			t.test("None", () => {
+				const got = None.or(None);
+				const want = None;
+				assert.equal(got, want);
+			});
+
+			t.test("Some", () => {
+				fc.assert(
+					fc.property(fc.anything(), (value) => {
+						const some = new Some(value);
+
+						const got = None.or(some);
+						const want = some;
+						assert.equal(got, want);
+					}),
+				);
+			});
+		});
+
 		t.test("value", () => {
 			assert.throws(
 				() => None.value(),
@@ -67,6 +87,37 @@ test("option.js", (t) => {
 					assert.equal(got, want);
 				}),
 			);
+		});
+
+		t.test("or", () => {
+			t.test("None", () => {
+				fc.assert(
+					fc.property(fc.anything(), (value) => {
+						const some = new Some(value);
+
+						const got = some.or(None);
+						const want = some;
+						assert.equal(got, want);
+					}),
+				);
+			});
+
+			t.test("Some", () => {
+				fc.assert(
+					fc.property(
+						fc.anything(),
+						fc.anything(),
+						(valueA, valueB) => {
+							const someA = new Some(valueA);
+							const someB = new Some(valueB);
+
+							const got = someA.or(someB);
+							const want = someA;
+							assert.equal(got, want);
+						},
+					),
+				);
+			});
 		});
 
 		t.test("value", () => {

--- a/src/result.js
+++ b/src/result.js
@@ -12,6 +12,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import { None, Some } from "./option.js";
+
 /**
  * @template O, P, E, F
  * @typedef Result
@@ -22,6 +24,7 @@
  * @property {function(): boolean} isOk
  * @property {function((ok: O) => P): Result<P, E>} map
  * @property {function((err: E) => F): Result<O, F>} mapErr
+ * @property {function(): Option<O>} ok
  * @property {function(): O} value
  */
 
@@ -94,6 +97,13 @@ export class Ok {
 	 */
 	mapErr() {
 		return this;
+	}
+
+	/**
+	 * @returns {Option<O>}
+	 */
+	ok() {
+		return new Some(this.#value);
 	}
 
 	/**
@@ -173,6 +183,13 @@ export class Err {
 	}
 
 	/**
+	 * @returns {Option<never>}
+	 */
+	ok() {
+		return None;
+	}
+
+	/**
 	 * @returns {never}
 	 * @throws {TypeError}
 	 */
@@ -184,3 +201,8 @@ export class Err {
 		);
 	}
 }
+
+/**
+ * @template T
+ * @typedef {import("./option.js").Option<T>} Option
+ */

--- a/src/result.test.js
+++ b/src/result.test.js
@@ -17,6 +17,7 @@ import { mock, test } from "node:test";
 
 import * as fc from "fast-check";
 
+import { None } from "./option.js";
 import { Err, Ok } from "./result.js";
 
 test("result.js", (t) => {
@@ -189,6 +190,16 @@ test("result.js", (t) => {
 					}),
 				);
 			});
+		});
+
+		t.test("ok", () => {
+			fc.assert(
+				fc.property(arbitrary.err(), (err) => {
+					const got = err.ok();
+					const want = None;
+					assert.equal(got, want);
+				}),
+			);
 		});
 
 		t.test("value", () => {
@@ -379,6 +390,19 @@ test("result.js", (t) => {
 					}),
 				);
 			});
+		});
+
+		t.test("ok", () => {
+			fc.assert(
+				fc.property(arbitrary.ok(), (ok) => {
+					const some = ok.ok();
+					assert.ok(some.isSome());
+
+					const got = some.value();
+					const want = ok.value();
+					assert.equal(got, want);
+				}),
+			);
 		});
 
 		t.test("value", () => {

--- a/src/version.js
+++ b/src/version.js
@@ -1,0 +1,133 @@
+// Copyright (C) 2025  Eric Cornelissen
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, version 3 of the License only.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import * as path from "node:path";
+import * as url from "node:url";
+
+import { parseJSON } from "./json.js";
+import { Err, Ok } from "./result.js";
+
+/**
+ * @param {object} p
+ * @param {ExecCP} p.cp
+ * @param {ReadFS} p.fs
+ * @returns {Promise<Versions>}
+ */
+export async function getVersions({ cp, fs }) {
+	const [depreman, node, npm, yarn] = await Promise.all([
+		selfVersion(fs),
+		nodeVersion(cp),
+		npmVersion(cp),
+		yarnVersion(cp),
+	]);
+
+	const err = node.and(depreman);
+	if (err.isErr()) {
+		return err;
+	}
+
+	if (yarn.or(npm).isNone()) {
+		return new Err("no package manager found");
+	}
+
+	const result = {
+		depreman: depreman.value(),
+		node: node.value(),
+	};
+
+	if (npm.isSome()) {
+		result.npm = npm.value();
+	}
+
+	if (yarn.isSome()) {
+		result.yarn = yarn.value();
+	}
+
+	return new Ok(result);
+}
+
+/**
+ * @param {ExecCP} cp
+ * @returns {Promise<Result<Version, string>>}
+ */
+async function nodeVersion(cp) {
+	const result = await cp.exec("node", ["--version"]);
+	return result
+		.map(({ stdout }) => stdout.slice(1).trim())
+		.mapErr(({ stderr }) => stderr);
+}
+
+/**
+ * @param {ExecCP} cp
+ * @returns {Promise<Option<Version>>}
+ */
+async function npmVersion(cp) {
+	const result = await cp.exec("npm", ["--version"]);
+	return result.map(({ stdout }) => stdout.trim()).ok();
+}
+
+/**
+ * @param {ExecCP} cp
+ * @returns {Promise<Option<Version>>}
+ */
+async function yarnVersion(cp) {
+	const result = await cp.exec("yarn", ["--version"]);
+	return result.map(({ stdout }) => stdout.trim()).ok();
+}
+
+/**
+ * @param {ReadFS} fs
+ * @returns {Promise<Result<Version, string>>}
+ */
+async function selfVersion(fs) {
+	const filepath = path.join(dirname(), "..", "package.json");
+	const result = await fs.readFile(filepath);
+	return result
+		.andThen(raw => parseJSON(raw))
+		.map(manifest => manifest.version);
+}
+
+/**
+ * @returns {string}
+ */
+function dirname() {
+	const scriptUrl = import.meta.url;
+	const scriptPath = url.fileURLToPath(scriptUrl);
+	return path.dirname(scriptPath);
+}
+
+/**
+ * @typedef {string} Version
+ */
+
+/**
+ * @typedef Versions
+ * @property {Version} depreman
+ * @property {Version} node
+ * @property {Version} [npm]
+ * @property {Version} [yarn]
+ */
+
+/** @typedef {import("./cp.js").ExecCP} ExecCP */
+/** @typedef {import("./fs.js").ReadFS} ReadFS */
+
+/**
+ * @template T
+ * @typedef {import("./option.js").Option<T>} Option
+ */
+
+/**
+ * @template O, E
+ * @typedef {import("./result.js").Result<O, E>} Result
+ */

--- a/src/version.test.js
+++ b/src/version.test.js
@@ -1,0 +1,172 @@
+// Copyright (C) 2025  Eric Cornelissen
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, version 3 of the License only.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import * as assert from "node:assert/strict";
+import * as path from "node:path";
+import { test } from "node:test";
+
+import { CP } from "./cp.mock.js";
+import { FS } from "./fs.mock.js";
+
+import { getVersions } from "./version.js";
+
+test("version.js", (t) => {
+	t.test("getVersions", (t) => {
+		const cmdNodeVersion = "node --version";
+		const cmdNpmVersion = "npm --version";
+		const cmdYarnVersion = "yarn --version";
+		const fileManifest = path.join(import.meta.dirname, "..", "package.json");
+
+		t.test("success", () => {
+			const depreman = "0.3.11";
+			const node = "24.4.1";
+			const npm = "11.4.2";
+			const yarn = "4.1.0";
+
+			t.test("with npm and yarn", async () => {
+				const cp = new CP({
+					[cmdNodeVersion]: { stdout: `v${node}\n` },
+					[cmdNpmVersion]: { stdout: `${npm}\n` },
+					[cmdYarnVersion]: { stdout: `${yarn}\n` },
+				});
+				const fs = new FS({
+					[fileManifest]: JSON.stringify({ version: depreman }),
+				});
+
+				const got = await getVersions({ cp, fs });
+				assert.ok(got.isOk());
+
+				const result = got.value();
+				assert.deepEqual(result, {
+					depreman,
+					node,
+					npm,
+					yarn,
+				});
+			});
+
+			t.test("with only npm", async () => {
+				const cp = new CP({
+					[cmdNodeVersion]: { stdout: `v${node}\n` },
+					[cmdNpmVersion]: { stdout: `${npm}\n` },
+					[cmdYarnVersion]: { error: true },
+				});
+				const fs = new FS({
+					[fileManifest]: JSON.stringify({ version: depreman }),
+				});
+
+				const got = await getVersions({ cp, fs });
+				assert.ok(got.isOk());
+
+				const result = got.value();
+				assert.deepEqual(result, {
+					depreman,
+					node,
+					npm,
+				});
+			});
+
+			t.test("with only yarn", async () => {
+				const cp = new CP({
+					[cmdNodeVersion]: { stdout: `v${node}\n` },
+					[cmdNpmVersion]: { error: true },
+					[cmdYarnVersion]: { stdout: `${yarn}\n` },
+				});
+				const fs = new FS({
+					[fileManifest]: JSON.stringify({ version: depreman }),
+				});
+
+				const got = await getVersions({ cp, fs });
+				assert.ok(got.isOk());
+
+				const result = got.value();
+				assert.deepEqual(result, {
+					depreman,
+					node,
+					yarn,
+				});
+			});
+		});
+
+		t.test("node version error", async () => {
+			const stderr = "could not get Node.js version";
+
+			const cp = new CP({
+				[cmdNodeVersion]: { error: true, stderr },
+				[cmdNpmVersion]: { stdout: "11.4.2\n" },
+				[cmdYarnVersion]: { stdout: "4.1.0\n" },
+			});
+			const fs = new FS({
+				[fileManifest]: JSON.stringify({ version: "0.3.11" }),
+			});
+
+			const got = await getVersions({ cp, fs });
+			assert.ok(got.isErr());
+
+			const err = got.error();
+			assert.equal(err, stderr);
+		});
+
+		t.test("all package manager version error", async () => {
+			const cp = new CP({
+				[cmdNodeVersion]: { stdout: "v24.4.1\n" },
+				[cmdNpmVersion]: { error: true },
+				[cmdYarnVersion]: { error: true },
+			});
+			const fs = new FS({
+				[fileManifest]: JSON.stringify({ version: "0.3.11" }),
+			});
+
+			const got = await getVersions({ cp, fs });
+			assert.ok(got.isErr());
+
+			const err = got.error();
+			assert.equal(err, "no package manager found");
+		});
+
+		t.test("self version error", (t) => {
+			t.test("corrupted", async () => {
+				const cp = new CP({
+					[cmdNodeVersion]: { stdout: "v24.4.1\n" },
+					[cmdNpmVersion]: { stdout: "11.4.2\n" },
+					[cmdYarnVersion]: { stdout: "4.1.0\n" },
+				});
+				const fs = new FS({
+					[fileManifest]: "garbage",
+				});
+
+				const got = await getVersions({ cp, fs });
+				assert.ok(got.isErr());
+
+				const err = got.error();
+				assert.match(err, /^Unexpected .+ JSON$/u);
+			});
+
+			t.test("not found", async () => {
+				const cp = new CP({
+					[cmdNodeVersion]: { stdout: "v24.4.1" },
+					[cmdNpmVersion]: { stdout: "11.4.2" },
+					[cmdYarnVersion]: { stdout: "4.1.0\n" },
+				});
+				const fs = new FS({});
+
+				const got = await getVersions({ cp, fs });
+				assert.ok(got.isErr());
+
+				const err = got.error();
+				assert.equal(err, "file not found");
+			});
+		});
+	});
+});

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -34,6 +34,17 @@ test("end-to-end", async (t) => {
 		assert.equal(result.stderr, "");
 	});
 
+	await t.test("--version", () => {
+		const result = cli({
+			args: ["--version"],
+			project: fixture("example"),
+		});
+
+		assert.equal(result.exitCode, 0);
+		assert.notEqual(result.stdout, "");
+		assert.equal(result.stderr, "");
+	});
+
 	await t.test("--omit=dev", () => {
 		const result = cli({
 			args: ["--omit=dev"],


### PR DESCRIPTION
Closes #210
Relates to #115, #148

## Summary

Add a `--version` flag to the Depreman CLI that outputs the current Depreman version (based on the manifest) as well as the versions of relevant software (Node.js, npm, yarn).

Update the issue templates accordingly to ask for the `--version` output instead of `npm ls` output (at least by default for now).

Deviating from #210, I opted to stick with a single `--version` flag to simplify usage. I felt that adding `--versions` separately would just be redundant and potentially confusing for users.