### PR TITLE
Refactor config validation

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -113,6 +113,8 @@ function validateDirectives(config, root) {
 				case "#ignore":
 					if (!(type === types.boolean || type === types.string)) {
 						problems.push(`unexpected type for '#ignore': ${type}`);
+					} else if (value.length === 0) {
+						problems.push("cannot use empty string for '#ignore'");
 					}
 					break;
 				case "#scope":

--- a/src/config.test.js
+++ b/src/config.test.js
@@ -52,7 +52,7 @@ test("config.js", (t) => {
 			"config with scope, one": {
 				config: {
 					"package@1.0.0": {
-						"#ignore": "until 2025-01-01",
+						"#ignore": "if production",
 						"#scope": ["prod"],
 					},
 				},
@@ -60,7 +60,7 @@ test("config.js", (t) => {
 			"config with scope, multiple": {
 				config: {
 					"package@1.0.0": {
-						"#ignore": "until 2025-01-01",
+						"#ignore": "if not production",
 						"#scope": ["dev", "optional", "peer"],
 					},
 				},
@@ -117,7 +117,17 @@ test("config.js", (t) => {
 				message: "package@1.0.0: unknown directive '#foo'\n"
 					+ "package@1.0.0: unknown directive '#bar'",
 			},
-			"incorrect type for '#ignore'": {
+			"incorrect type for '#ignore', number": {
+				config: {
+					"foo@3.0.0": {
+						"bar@1.4.0": {
+							"#ignore": 42,
+						},
+					},
+				},
+				message: "foo@3.0.0: bar@1.4.0: unexpected type for '#ignore': number",
+			},
+			"incorrect type for '#ignore', array": {
 				config: {
 					"foo@3.0.0": {
 						"bar@1.4.0": {
@@ -126,6 +136,24 @@ test("config.js", (t) => {
 					},
 				},
 				message: "foo@3.0.0: bar@1.4.0: unexpected type for '#ignore': array",
+			},
+			"incorrect type for '#ignore', object": {
+				config: {
+					"foo@3.0.0": {
+						"bar@1.4.0": {
+							"#ignore": {},
+						},
+					},
+				},
+				message: "foo@3.0.0: bar@1.4.0: unexpected type for '#ignore': object",
+			},
+			"incorrect value for '#ignore', empty string": {
+				config: {
+					"foobar@3.1.4": {
+						"#ignore": "",
+					},
+				},
+				message: "foobar@3.1.4: cannot use empty string for '#ignore'",
 			},
 			"incorrect type for '#expire'": {
 				config: {

--- a/src/ignores.js
+++ b/src/ignores.js
@@ -135,7 +135,6 @@ function isIgnored(config, path, pkg={}) {
  * @param {Config} config
  * @param {Package} pkg
  * @returns {boolean | string}
- * @throws {Error}
  */
 function getDecision(config, pkg) {
 	const decision = parseDecision(config);
@@ -149,29 +148,18 @@ function getDecision(config, pkg) {
 /**
  * @param {Config} config
  * @returns {boolean | string}
- * @throws {Error}
  */
 function parseDecision(config) {
 	let ignore = false;
 	if (Object.hasOwn(config, kIgnore)) {
 		ignore = config[kIgnore];
 		config[kUsed] = true;
-	} else if (Object.hasOwn(config["*"] || {}, kIgnore)) {
+	} else if (Object.hasOwn(config["*"], kIgnore)) {
 		ignore = config["*"][kIgnore];
 		config["*"][kUsed] = true;
 	}
 
-	switch (typeOf(ignore)) {
-		case types.boolean:
-		case types.string:
-			if (ignore.length === 0) {
-				throw new Error(`cannot use empty string for '${kIgnore}', use 'true' instead`);
-			} else {
-				return ignore;
-			}
-		default:
-			throw new Error(`invalid '${kIgnore}' value: ${ignore}`);
-	}
+	return ignore;
 }
 
 /**

--- a/src/ignores.test.js
+++ b/src/ignores.test.js
@@ -1174,66 +1174,6 @@ test("ignore.js", (t) => {
 				],
 				want: /^Error: invalid rule name '3.1.4'$/u,
 			},
-			"invalid '#ignore' value, empty string": {
-				config: {
-					"package@1.0.0": {
-						"#ignore": "",
-					},
-				},
-				deprecations: [
-					{
-						name: "package",
-						version: "1.0.0",
-						reason: "foobar",
-						paths: [
-							[
-								{ name: "package", version: "1.0.0" },
-							],
-						],
-					},
-				],
-				want: /^Error: cannot use empty string for '#ignore', use 'true' instead$/u,
-			},
-			"invalid '#ignore' value, array": {
-				config: {
-					"package@3.1.4": {
-						"#ignore": [],
-					},
-				},
-				deprecations: [
-					{
-						name: "package",
-						version: "3.1.4",
-						reason: "foobar",
-						paths: [
-							[
-								{ name: "package", version: "3.1.4" },
-							],
-						],
-					},
-				],
-				want: /^Error: invalid '#ignore' value/u,
-			},
-			"invalid '#ignore' value, object": {
-				config: {
-					"package@3.1.4": {
-						"#ignore": {},
-					},
-				},
-				deprecations: [
-					{
-						name: "package",
-						version: "3.1.4",
-						reason: "foobar",
-						paths: [
-							[
-								{ name: "package", version: "3.1.4" },
-							],
-						],
-					},
-				],
-				want: /^Error: invalid '#ignore' value/u,
-			},
 		};
 
 		for (const [name, testCase] of Object.entries(badTestCases)) {

--- a/src/object.js
+++ b/src/object.js
@@ -32,6 +32,10 @@ function entries(obj) {
  * @returns {boolean}
  */
 function hasOwn(obj, key) {
+	if (typeOf(obj) === "undefined" || typeOf(obj) === "null") {
+		return false;
+	}
+
 	return Object.hasOwn(obj, key);
 }
 

--- a/src/object.test.js
+++ b/src/object.test.js
@@ -71,19 +71,6 @@ test("object.js", (t) => {
 	});
 
 	t.test("hasOwn", (t) => {
-		t.test("return value", () => {
-			fc.assert(
-				fc.property(
-					fc.object(),
-					fc.string(),
-					(object, key) => {
-						const got = Object.hasOwn(object, key);
-						assert.equal(typeof got, "boolean");
-					},
-				),
-			);
-		});
-
 		t.test("own key", () => {
 			fc.assert(
 				fc.property(
@@ -116,6 +103,26 @@ test("object.js", (t) => {
 						assert.equal(got, false);
 					},
 				),
+			);
+		});
+
+		t.test("undefined", () => {
+			fc.assert(
+				fc.property(fc.string(), (key) => {
+						const got = Object.hasOwn(undefined, key);
+						const want = false;
+						assert.deepEqual(got, want);
+				}),
+			);
+		});
+
+		t.test("null", () => {
+			fc.assert(
+				fc.property(fc.string(), (key) => {
+					const got = Object.hasOwn(null, key);
+					const want = false;
+					assert.deepEqual(got, want);
+				}),
 			);
 		});
 	});


### PR DESCRIPTION
Migrate config validation from `ignores.js` to `config.js` to consolidate it.