### PR TITLE
Add a manpage for the `depreman` CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Versioning].
 
 ## Unreleased
 
-- _No changes yet_
+- Add a manpage.
 
 ## 0.3.12 (2025-09-27)
 

--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -18,7 +18,7 @@
 FROM docker.io/node:24.4.1-alpine3.22
 
 RUN apk add --no-cache \
-  bash git \
+  bash git mandoc \
   && \
   git config --global --add safe.directory /depreman
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -21,24 +21,31 @@ found in this document.
    ```
 
 1. Pick a new version number in accordance with [Semantic Versioning]. For this
-   example we'll use `0.3.1`.
+   example we'll use `0.3.4`.
 
 1. Update the version number in the package manifest and lockfile:
 
    ```shell
-   npm version --no-git-tag-version 0.3.1
+   npm version --no-git-tag-version 0.3.4
    ```
 
    If that fails, change the value of the version field in `package.json` to the
    new version:
 
    ```diff
-   -  "version": "0.3.0",
-   +  "version": "0.3.1",
+   -  "version": "0.3.3",
+   +  "version": "0.3.4",
    ```
 
    and update the version number in `package-lock.json` using `npm install`
    (after updating `package.json`), which will sync the version number.
+
+1. Update the date and version number in the man page at `bin/man/depreman.1`:
+
+   ```diff
+   -  .TH "depreman" "1" "November 2024" "v0.3.3" "User Commands"
+   +  .TH "depreman" "1" "December 2024" "v0.3.4" "User Commands"
+   ```
 
 1. Update the `CHANGELOG.md`, manually add the following text after the
    `## [Unreleased]` line:
@@ -46,7 +53,7 @@ found in this document.
    ```markdown
    - _No changes yet_
 
-   ## 0.3.1 (YYYY-MM-DD)
+   ## 0.3.4 (YYYY-MM-DD)
    ```
 
    The date should follow the year-month-day format where single-digit months

--- a/bin/man/depreman.1
+++ b/bin/man/depreman.1
@@ -1,0 +1,56 @@
+.TH "depreman" "1" "November 2025" "v0.3.12" "User Commands"
+.SH NAME
+depreman \- manage npm deprecation warnings
+.SH SYNOPSIS
+.B depreman
+[OPTION]...
+.SH DESCRIPTION
+.P
+Manage the npm registry deprecation warnings of the current npm or yarn project.
+.P
+Reads from '.ndmrc' in the current directory, a JSON\-based file of deprecation
+warnings to ignore based on the package\'s location in the dependency hierarchy.
+.P
+Need more help? Found a bug? Missing something? See:
+<https://github.com/ericcornelissen/depreman/issues/new/choose>
+.SH OPTIONS
+.TP
+.B -h, --help
+Show the help message.
+.TP
+.B --errors-only
+Only output deprecation warnings that are not ignored.
+.TP
+.B --omit=<dev|optional|peer>
+Omit deprecation warnings for development, optional, or peer dependencies.
+.TP
+.B --package-manager=<npm|yarn>
+Which package manager to use, 'npm' (default) or 'yarn'.
+.TP
+.B --report-unused
+Report and fail for unused ignore directives.
+.TP
+.B --version
+Show the version of this and relevant software.
+.SH EXIT STATUS
+.TP
+.B 0
+No deprecation warnings found.
+.TQ
+.B 1
+At least one (not ignored) deprecation warning found.
+.TQ
+.B 2
+An unexpected error occurred, the program failed to complete.
+.SH AUTHOR
+.P
+Written by Eric Cornelissen.
+.SH COPYRIGHT
+.P
+Copyright (C) 2025 Eric Cornelissen
+.P
+License AGPLv3: GNU Affero GPL version 3
+<https://www.gnu.org/licenses/agpl-3.0.html>
+.P
+This is free software: you are free to change and redistribute it.
+There is NO WARRANTY, to the extent permitted by applicable law.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "deprecations"
   ],
   "bin": "./bin/cli.js",
+  "man": "./bin/man/depreman.1",
   "type": "module",
   "engines": {
     "node": "^20 || ^22 || ^24",


### PR DESCRIPTION
Closes #209

## Summary

Following the [npm docs], this adds a manpage for the `depreman` CLI. This enables the use of `man depreman` to get a manual page for the CLI. Currently, my goal for this is to go beyond the `--help` content and lean a bit more towards a README for how to use the software. This is, of course, a vague distinction that is also not set in stone. The current content and structure are based in part on `man base64` and `man timeout`.

I worked on this with a bit of help from [a random blog post].

The manual page includes the program version and release month+year, hence the release guidelines have been updated to include a step to update it. To make the example diff realistic I changed the example versions to two versions that were released in different months.

[npm docs]: https://docs.npmjs.com/cli/v11/configuring-npm/package-json#man
[a random blog post]: https://www.hughrawlinson.me/posts/2021/07/09/how-to-ship-man-pages-with-your-node-programs
