### PR TITLE
Implement hardening techniques against monkey patching

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,8 +1,26 @@
 #!/usr/bin/env node
 
+// Copyright (C) 2024-2025  Eric Cornelissen
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, version 3 of the License only.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import { argv, exit } from "node:process";
 
-import { cli } from "../src/main.js";
+delete Object.prototype.__proto__; // eslint-disable-line no-proto
+Object.freeze(Object.prototype);
+Object.freeze(Array.prototype);
+Object.freeze(globalThis);
 
+const { cli } = await import("../src/main.js");
 const exitCode = await cli(argv);
 exit(exitCode);


### PR DESCRIPTION
Add various hardening measures against monkey patching, following <https://nodejs.org/en/learn/getting-started/security-best-practices>, for the CLI.[^1]

[^1]: We can't do this for the "library part" as (future) users would not expect this.