### PR TITLE
Disallow general use of `throw`ing errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,7 @@ import top from "@ericcornelissen/eslint-plugin-top";
 import json from "@eslint/json";
 import markdown from "@eslint/markdown";
 import depend from "eslint-plugin-depend";
+import functional from "eslint-plugin-functional";
 import imports from "eslint-plugin-import";
 import jsdoc from "eslint-plugin-jsdoc";
 import regexp from "eslint-plugin-regexp";
@@ -26,6 +27,7 @@ export default [
 		},
 		plugins: {
 			depend,
+			functional,
 			imports,
 			jsdoc,
 			regexp,
@@ -254,6 +256,11 @@ export default [
 						"eslint-plugin-unicorn",
 					],
 				}],
+			},
+
+			// eslint-plugin-functional
+			...{
+				"functional/no-throw-statements": "error",
 			},
 
 			// eslint-plugin-import

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "better-npm-audit": "3.11.0",
         "eslint": "9.38.0",
         "eslint-plugin-depend": "1.3.1",
+        "eslint-plugin-functional": "9.0.2",
         "eslint-plugin-import": "2.32.0",
         "eslint-plugin-jsdoc": "61.2.0",
         "eslint-plugin-regexp": "2.9.0",
@@ -2398,12 +2399,194 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@typescript-eslint/types": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.46.2.tgz",
-      "integrity": "sha512-lNCWCbq7rpg7qDsQrd3D6NyWYu+gkTENkG5IKYhUIcxSb59SQC/hEQ+MrG4sTgBVghTonNWq42bA/d4yYumldQ==",
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.47.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.47.0.tgz",
+      "integrity": "sha512-2X4BX8hUeB5JcA1TQJ7GjcgulXQ+5UkNb0DL8gHsHUHdFoiCTJoYLTpib3LtSDPZsRET5ygN4qqIWrHyYIKERA==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.47.0",
+        "@typescript-eslint/types": "^8.47.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.47.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.47.0.tgz",
+      "integrity": "sha512-a0TTJk4HXMkfpFkL9/WaGTNuv7JWfFTQFJd6zS9dVAjKsojmv9HT55xzbEpnZoY+VUb+YXLMp+ihMLz/UlZfDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.47.0",
+        "@typescript-eslint/visitor-keys": "8.47.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.47.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.47.0.tgz",
+      "integrity": "sha512-ybUAvjy4ZCL11uryalkKxuT3w3sXJAuWhOoGS3T/Wu+iUu1tGJmk5ytSY8gbdACNARmcYEB0COksD2j6hfGK2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.47.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.47.0.tgz",
+      "integrity": "sha512-QC9RiCmZ2HmIdCEvhd1aJELBlD93ErziOXXlHEZyuBo3tBiAZieya0HLIxp+DoDWlsQqDawyKuNEhORyku+P8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.47.0",
+        "@typescript-eslint/typescript-estree": "8.47.0",
+        "@typescript-eslint/utils": "8.47.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.47.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.47.0.tgz",
+      "integrity": "sha512-nHAE6bMKsizhA2uuYZbEbmp5z2UpffNrPEqiKIeN7VsV6UY/roxanWfoRrf6x/k9+Obf+GQdkm0nPU+vnMXo9A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.47.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.47.0.tgz",
+      "integrity": "sha512-k6ti9UepJf5NpzCjH31hQNLHQWupTRPhZ+KFF8WtTuTpy7uHPfeg2NM7cP27aCGajoEplxJDFVCEm9TGPYyiVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.47.0",
+        "@typescript-eslint/tsconfig-utils": "8.47.0",
+        "@typescript-eslint/types": "8.47.0",
+        "@typescript-eslint/visitor-keys": "8.47.0",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.47.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.47.0.tgz",
+      "integrity": "sha512-g7XrNf25iL4TJOiPqatNuaChyqt49a/onq5YsJ9+hXeugK+41LVg7AxikMfM02PC6jbNtZLCJj6AUcQXJS/jGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.47.0",
+        "@typescript-eslint/types": "8.47.0",
+        "@typescript-eslint/typescript-estree": "8.47.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.47.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.47.0.tgz",
+      "integrity": "sha512-SIV3/6eftCy1bNzCQoPmbWsRLujS8t5iDIZ4spZOBHqrM+yfX2ogg8Tt3PDTAVKw3sSCiUgg30uOAvK2r9zGjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.47.0",
+        "eslint-visitor-keys": "^4.2.1"
+      },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -3711,6 +3894,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deepmerge-ts": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
+      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -4277,6 +4470,56 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-functional": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-functional/-/eslint-plugin-functional-9.0.2.tgz",
+      "integrity": "sha512-N8kP9HX1CJ2HrufPHLzsKNJ81O1IB25jw2mxOc1H1z3CamEu8MYTn9dOo/FPfQwsqHZVuf7wyDCBcL8r8H7N0w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "ko-fi",
+          "url": "https://ko-fi.com/rebeccastevens"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/eslint-plugin-functional"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^8.26.0",
+        "deepmerge-ts": "^7.1.5",
+        "escape-string-regexp": "^5.0.0",
+        "is-immutable-type": "^5.0.1",
+        "ts-api-utils": "^2.0.1",
+        "ts-declaration-location": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=v18.18.0"
+      },
+      "peerDependencies": {
+        "eslint": "^9.0.0",
+        "typescript": ">=4.7.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-functional/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-plugin-import": {
@@ -7141,6 +7384,22 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-immutable-type": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/is-immutable-type/-/is-immutable-type-5.0.1.tgz",
+      "integrity": "sha512-LkHEOGVZZXxGl8vDs+10k3DvP++SEoYEAJLRk6buTFi6kD7QekThV7xHS0j6gpnUCQ0zpud/gMDGiV4dQneLTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@typescript-eslint/type-utils": "^8.0.0",
+        "ts-api-utils": "^2.0.0",
+        "ts-declaration-location": "^1.0.4"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "typescript": ">=4.7.4"
       }
     },
     "node_modules/is-lambda": {
@@ -13179,6 +13438,55 @@
         "node": ">=8"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-declaration-location": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/ts-declaration-location/-/ts-declaration-location-1.0.7.tgz",
+      "integrity": "sha512-EDyGAwH1gO0Ausm9gV6T2nUvBgXT5kGoCMJPllOaooZ+4VvJiKBdZE7wK18N1deEowhcUptS+5GXZK8U/fvpwA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "ko-fi",
+          "url": "https://ko-fi.com/rebeccastevens"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/ts-declaration-location"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "picomatch": "^4.0.2"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.0.0"
+      }
+    },
+    "node_modules/ts-declaration-location/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -13366,6 +13674,21 @@
       },
       "engines": {
         "node": ">= 16.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "better-npm-audit": "3.11.0",
     "eslint": "9.38.0",
     "eslint-plugin-depend": "1.3.1",
+    "eslint-plugin-functional": "9.0.2",
     "eslint-plugin-import": "2.32.0",
     "eslint-plugin-jsdoc": "61.2.0",
     "eslint-plugin-regexp": "2.9.0",

--- a/src/cp.mock.js
+++ b/src/cp.mock.js
@@ -41,7 +41,7 @@ export class CP {
 				}
 			}
 
-			throw new Error(`command not found '${want}'`);
+			throw new Error(`command not found '${want}'`); // eslint-disable-line functional/no-throw-statements
 		});
 	}
 }

--- a/src/date.js
+++ b/src/date.js
@@ -80,7 +80,7 @@ export class DepremanDate {
 	 */
 	is(other) {
 		if (!(other instanceof DepremanDate)) {
-			throw new TypeError("other is not a date");
+			throw new TypeError("other is not a date"); // eslint-disable-line functional/no-throw-statements
 		}
 
 		return this.#year === other.#year
@@ -95,7 +95,7 @@ export class DepremanDate {
 	 */
 	isBefore(other) {
 		if (!(other instanceof DepremanDate)) {
-			throw new TypeError("other is not a date");
+			throw new TypeError("other is not a date"); // eslint-disable-line functional/no-throw-statements
 		}
 
 		if (this.#year < other.#year) {

--- a/src/ignores.js
+++ b/src/ignores.js
@@ -26,7 +26,6 @@ const kUsed = Symbol.for("#used"); // eslint-disable-line top/no-top-level-side-
  * @param {Config} config
  * @param {DeprecatedPackage[]} deprecations
  * @returns {DeprecationVerdict[]}
- * @throws {Error}
  */
 export function removeIgnored(config, deprecations) {
 	const result = [];
@@ -85,7 +84,6 @@ export function unusedIgnores(config, path=[]) {
  * @param {Package[]} path
  * @param {Package} pkg
  * @returns {boolean | string}
- * @throws {Error}
  */
 function isIgnored(config, path, pkg={}) {
 	if (path.length === 0) {

--- a/src/main.js
+++ b/src/main.js
@@ -72,8 +72,14 @@ async function depreman(options) {
 			getDeprecatedPackages(pm),
 		]);
 
-		if (deprecations.and(config).isErr()) {
-			throw new Error(deprecations.and(config).error());
+		if (config.isErr()) {
+			stderr.write(`configuration error: ${config.error()}\n`);
+			return EXIT_CODE_UNEXPECTED;
+		}
+
+		if (deprecations.isErr()) {
+			stderr.write(`error obtaining deprecations: ${deprecations.error()}\n`);
+			return EXIT_CODE_UNEXPECTED;
 		}
 
 		const result = removeIgnored(config.value(), deprecations.value());

--- a/src/option.js
+++ b/src/option.js
@@ -95,6 +95,6 @@ export const None = {
 	 * @throws {TypeError}
 	 */
 	value() {
-		throw new TypeError("None has no value");
+		throw new TypeError("None has no value"); // eslint-disable-line functional/no-throw-statements
 	},
 }

--- a/src/result.js
+++ b/src/result.js
@@ -64,7 +64,7 @@ export class Ok {
 	 * @throws {TypeError}
 	 */
 	error() {
-		throw new TypeError("Ok has no error");
+		throw new TypeError("Ok has no error"); // eslint-disable-line functional/no-throw-statements
 	}
 
 	/**
@@ -194,7 +194,7 @@ export class Err {
 	 * @throws {TypeError}
 	 */
 	value() {
-		throw (
+		throw ( // eslint-disable-line functional/no-throw-statements
 			typeof this.#error === "string"
 				? new TypeError(this.#error)
 				: new TypeError("Err has no value")


### PR DESCRIPTION
Following refactoring efforts to move from `throw`ing errors to using [`Result`s](https://github.com/ericcornelissen/depreman/blob/2ffaad8d068aa7b14613a12c51c3e672edc4ff9e/src/result.js), this change aims to enforce this practice. This is achieved by add `eslint-plugin-functional` to enable an ESLint rule that forbids the use of `throw`.[^1]


[^1]: further rules of this plugin are deferred to later for consideration.