### PR TITLE
Address GHSA-8qq5-rm4j-mr97

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,3 +1,13 @@
 {
-    "GHSA-c2qf-rxjj-qqgw": "fixed version is within the supported version range"
+  "GHSA-c2qf-rxjj-qqgw": "fixed version is within the supported version range",
+  "GHSA-8qq5-rm4j-mr97": {
+    "active": true,
+    "expiry": "2026-06-01",
+    "notes": "Present only through licensee where it is low risk as a (transitive) dev dependency"
+  },
+  "GHSA-r6q2-hw4h-h46w": {
+    "active": true,
+    "expiry": "2026-06-01",
+    "notes": "Present only through licensee where it is low risk as a (transitive) dev dependency"
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2780,6 +2781,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2837,6 +2839,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3219,6 +3222,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -4319,6 +4323,7 @@
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6247,9 +6252,9 @@
       }
     },
     "node_modules/get-dep-tree/node_modules/tar": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.2.tgz",
-      "integrity": "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.3.tgz",
+      "integrity": "sha512-ENg5JUHUm2rDD7IvKNFGzyElLXNjachNLp6RaGf4+JOgxXHkqA+gq81ZAMCUmtMtqBsoU62lcp6S27g1LCYGGQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -11767,6 +11772,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12554,6 +12560,7 @@
       "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },


### PR DESCRIPTION
Bump tar where possible and ignore, with reason and expiry date, using better-npm-audit otherwise. See https://github.com/ericcornelissen/shescape/pull/2327#issuecomment-3764123085 for a more detailed analysis. Everything applies here except that `ava` is irrelevant.

I'm planning to leave this open for a few days as well to see how the `licensee` situation plays out or whether the fix is backported to `tar@^6`.