### PR TITLE
Set `allow-git=none` for npm

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,6 @@
 # Configuration file for npm (https://docs.npmjs.com/cli/configuring-npm/npmrc)
 
+allow-git=none
 audit=false
 ignore-scripts=true
 lockfile-version=3


### PR DESCRIPTION
## Summary

Update the npm configuration to disable git dependencies as a security hardening measure. It "Limits the ability for npm to fetch dependencies from git references." Helping by aiding availability (since git deps, unlike registry deps, may disappear overnight) and prevents further installation time code execution (like `ignore-scripts=true`).

This was added following the [announcement by GitHub](https://github.blog/changelog/2026-02-18-npm-bulk-trusted-publishing-config-and-script-security-now-generally-available/) -- who have not yet updated the online npm documentation :unamused: -- and was tested for availability locally (on v11.10.1) where it worked (unlike v11.6.2 which outputs a warning that "allow-git" is unknown and confusingly says it will stop working in the next version[^1], but ow well :shrug:)

[^1]: presumably intended to mean that using unknown options will stop working, but the wording is ambiguous.