### PR TITLE
Set up `strip-directives`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,5 +64,9 @@ jobs:
           registry-url: https://registry.npmjs.org
       - name: Install dependencies
         run: npm clean-install
+      - name: Package the project
+        env:
+          NODE_DEBUG: strip-directives
+        run: npm run package
       - name: Publish to npm
         run: npm publish || true

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "ls-engines": "0.10.0",
         "npm-package-json-lint": "10.4.0",
         "publint": "0.3.20",
+        "strip-directives": "2.0.0",
         "which": "7.0.0"
       },
       "engines": {
@@ -9917,6 +9918,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-comments-js": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/strip-comments-js/-/strip-comments-js-1.0.10.tgz",
+      "integrity": "sha512-FKNBl6WhRR64rsCRoOca7+B3V/TT8f2Mcy094jDtXjmEeiy3HpZLyZT9Gmd5xPjSXsDJalOe4uQ0vVXr1hb41g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "strip-comments-js": "bin.js"
+      },
+      "engines": {
+        "node": "^24 || ^26"
+      }
+    },
+    "node_modules/strip-directives": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-directives/-/strip-directives-2.0.0.tgz",
+      "integrity": "sha512-HK732NGPyEmmU/Z/u0DgA/0DQfB/yShsBtUhvaQxxfAwjY7FhGSZVG7Tc8d55t9pFLn52k83IeQx6+WBJYh9Pw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "strip-comments-js": "^1.0.7"
+      },
+      "bin": {
+        "strip-directives": "bin.js"
+      },
+      "engines": {
+        "node": "^24 || ^26"
       }
     },
     "node_modules/strip-final-newline": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "dev-img": "docker build --file Containerfile.dev --tag depreman-dev-img .",
     "dogfeed": "node bin/cli.js --errors-only --report-unused",
     "mutation": "stryker run .stryker.js",
+    "package": "strip-directives bin/*.js src/*.js",
     "test": "npm run test:unit && npm run test:e2e",
     "test:unit": "node --test 'src/*.test.js'",
     "test:watch": "node --test --watch 'src/*.test.js'",
@@ -84,6 +85,7 @@
     "ls-engines": "0.10.0",
     "npm-package-json-lint": "10.4.0",
     "publint": "0.3.20",
+    "strip-directives": "2.0.0",
     "which": "7.0.0"
   }
 }


### PR DESCRIPTION
## Summary

Add [`strip-directives`](https://www.npmjs.com/package/strip-directives) and use it to strip the source code of directives before publishing the package to the npm registry.