### PR TITLE
Explicitly configuring all `eslint-plugin-functional` rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -258,7 +258,25 @@ export default [
 
 			// eslint-plugin-functional
 			...{
+				"functional/functional-parameters": "off",
+				"functional/immutable-data": "off",
+				"functional/no-classes": "off",
+				"functional/no-class-inheritance": "error",
+				"functional/no-conditional-statements": "off",
+				"functional/no-expression-statements": "off",
+				"functional/no-let": "error",
 				"functional/no-throw-statements": "error",
+				"functional/no-loop-statements": "off",
+				"functional/no-mixed-types": "off",
+				"functional/no-promise-reject": "error",
+				"functional/no-return-void": "off",
+				"functional/no-this-expressions": "off",
+				"functional/no-try-statements": "error",
+				"functional/prefer-immutable-types": "off",
+				"functional/prefer-property-signatures": "off",
+				"functional/prefer-tacit": "off",
+				"functional/readonly-type": "off",
+				"functional/type-declaration-immutability": "off",
 			},
 
 			// eslint-plugin-jsdoc
@@ -1059,6 +1077,9 @@ export default [
 			"no-console": "off",
 			"no-await-in-loop": "off",
 
+			// eslint-plugin-functional
+			"functional/no-let": "off",
+
 			// eslint-plugin-jsdoc
 			"jsdoc/require-jsdoc": "off",
 
@@ -1080,9 +1101,14 @@ export default [
 			"max-lines": "off",
 			"no-await-in-loop": "off",
 			"no-magic-numbers": "off",
+			"no-new": "off",
 			"no-shadow": ["error", {
 				allow: ["t"],
 			}],
+
+			// eslint-plugin-functional
+			"functional/no-promise-reject": "off",
+			"functional/no-try-statements": "off",
 
 			// eslint-plugin-import
 			"imports/order": "off",
@@ -1105,6 +1131,9 @@ export default [
 		name: "Mocks",
 		files: ["**/*.mock.js"],
 		rules: {
+			// eslint-plugin-functional
+			"functional/no-throw-statements": "off",
+
 			// eslint-plugin-unicorn
 			"unicorn/consistent-boolean-name": "off",
 		},

--- a/bin/man/depreman.1
+++ b/bin/man/depreman.1
@@ -47,7 +47,7 @@ An unexpected error occurred, the program failed to complete.
 Written by Eric Cornelissen.
 .SH COPYRIGHT
 .P
-Copyright (C) 2025 Eric Cornelissen
+Copyright \(co 2026 Eric Cornelissen
 .P
 License AGPLv3: GNU Affero GPL version 3
 <https://www.gnu.org/licenses/agpl-3.0.html>

--- a/src/cp.mock.js
+++ b/src/cp.mock.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2025  Eric Cornelissen
+// Copyright (C) 2025-2026  Eric Cornelissen
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
@@ -41,7 +41,7 @@ export class CP {
 				}
 			}
 
-			throw new Error(`command not found '${want}'`); // eslint-disable-line functional/no-throw-statements
+			throw new Error(`command not found '${want}'`);
 		});
 	}
 }

--- a/src/date.test.js
+++ b/src/date.test.js
@@ -274,7 +274,7 @@ test("date.js", (t) => {
 					arbitrary.rawDate(),
 					(raw) => {
 						assert.doesNotThrow(() => {
-							new DepremanDate(raw); // eslint-disable-line no-new
+							new DepremanDate(raw);
 						});
 					},
 				),

--- a/src/fs.js
+++ b/src/fs.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2025  Eric Cornelissen
+// Copyright (C) 2025-2026  Eric Cornelissen
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
@@ -32,6 +32,7 @@ export class FS {
 	 * @returns {Promise<boolean>}
 	 */
 	async access(filepath) {
+		// eslint-disable-next-line functional/no-try-statements -- external API
 		try {
 			await this.#fs.access(filepath);
 			return true;
@@ -45,8 +46,9 @@ export class FS {
 	 * @returns {Promise<Result<string, string>>}
 	 */
 	async readFile(filepath) {
-		const options = { encoding: "utf8" };
+		// eslint-disable-next-line functional/no-try-statements -- external API
 		try {
+			const options = { encoding: "utf8" };
 			const content = await this.#fs.readFile(filepath, options);
 			return new Ok(content);
 		} catch (error) {

--- a/src/json.js
+++ b/src/json.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2025  Eric Cornelissen
+// Copyright (C) 2025-2026  Eric Cornelissen
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
@@ -19,6 +19,7 @@ import { Err, Ok } from "./result.js";
  * @returns {Result<unknown, string>}
  */
 export function parseJSON(raw) {
+	// eslint-disable-next-line functional/no-try-statements -- external API
 	try {
 		return new Ok(JSON.parse(raw));
 	} catch (error) {

--- a/src/json.test.js
+++ b/src/json.test.js
@@ -39,23 +39,23 @@ test("json.js", (t) => {
 
 		t.test("non-json", () => {
 			fc.assert(
-				fc.property(fc.string(), (value) => {
-					let didParse = false;
-					try {
-						JSON.parse(value);
-						didParse = true;
-					} catch {
-						// Nothing to do
-					}
-
-					if (didParse) {
-						fc.pre(false);
-					}
-
-					const got = parseJSON(value);
-					assert.ok(got.isErr());
-				}),
+				fc.property(
+					fc.string().filter(string => !isJSON(string)),
+					(string) => {
+						const got = parseJSON(string);
+						assert.ok(got.isErr());
+					},
+				),
 			);
 		});
 	});
 });
+
+function isJSON(string) {
+	try {
+		JSON.parse(string);
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/src/main.js
+++ b/src/main.js
@@ -24,7 +24,7 @@ import { FS } from "./fs.js";
 import { removeIgnored, unusedIgnores } from "./ignores.js";
 import { NPM } from "./npm.js";
 import { Object } from "./object.js";
-import { printAndExit } from "./output.js";
+import { isSuccess, makeReport } from "./output.js";
 import * as style from "./style.js";
 import { getVersions } from "./version.js";
 import { Yarn } from "./yarn.js";
@@ -52,6 +52,7 @@ export async function cli(argv) {
 		return await versions();
 	}
 
+	// eslint-disable-next-line functional/no-try-statements
 	try {
 		return await depreman(options.value());
 	} catch (error) {
@@ -88,11 +89,12 @@ async function depreman(options) {
 
 	const result = removeIgnored(config.value(), deprecations.value());
 	const unused = options.reportUnused ? unusedIgnores(config.value()) : [];
-	const { ok, report } = printAndExit(result, unused, options, style.create());
+	const report = makeReport(result, unused, options, style.create());
 	if (report) {
 		stdout.write(`${report}\n`);
 	}
 
+	const ok = isSuccess(result, unused);
 	return ok ? EXIT_CODE_SUCCESS : EXIT_CODE_FAILURE;
 }
 

--- a/src/npm.js
+++ b/src/npm.js
@@ -237,13 +237,13 @@ export class NPM {
 
 		const string = line.slice(prefix.length);
 
-		let index = string.indexOf(":");
-		const pkg = string.slice(0, index);
-		const reason = string.slice(index + 1).trim();
+		const firstColonIndex = string.indexOf(":");
+		const pkg = string.slice(0, firstColonIndex);
+		const reason = string.slice(firstColonIndex + 1).trim();
 
-		index = pkg.lastIndexOf("@");
-		const name = pkg.slice(0, index);
-		const version = pkg.slice(index + 1);
+		const lastAtIndex = pkg.lastIndexOf("@");
+		const name = pkg.slice(0, lastAtIndex);
+		const version = pkg.slice(lastAtIndex + 1);
 
 		return new Some({ name, version, reason });
 	}

--- a/src/output.js
+++ b/src/output.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025  Eric Cornelissen
+// Copyright (C) 2024-2026  Eric Cornelissen
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
@@ -17,12 +17,30 @@ import { typeOf, types } from "./types.js";
 /**
  * @param {Results} result
  * @param {Unused} unused
+ * @returns {boolean}
+ */
+export function isSuccess(result, unused) {
+	if (unused.length > 0) {
+		return false;
+	}
+
+	for (const pkg of result.toSorted(byName)) {
+		if (pkg.kept.length > 0) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/**
+ * @param {Results} result
+ * @param {Unused} unused
  * @param {Options} options
  * @param {Styler} chalk
- * @returns {{ok: boolean, result: string}}
+ * @returns {string}
  */
-export function printAndExit(result, unused, options, chalk) {
-	let ok = true;
+export function makeReport(result, unused, options, chalk) {
 	const output = [];
 
 	for (const pkg of result.toSorted(byName)) {
@@ -30,7 +48,6 @@ export function printAndExit(result, unused, options, chalk) {
 
 		const header = `${id} ${chalk.italic(`("${pkg.reason}")`)}:`;
 		if (pkg.kept.length > 0) {
-			ok = false;
 			output.push(header);
 		} else if (options.everything) {
 			output.push(chalk.dim(header));
@@ -52,17 +69,13 @@ export function printAndExit(result, unused, options, chalk) {
 	}
 
 	if (unused.length > 0) {
-		ok = false;
 		output.push("Unused ignore directives(s):");
 		for (const path of unused) {
 			output.push(`\t. > ${path.join(" > ")}`);
 		}
 	}
 
-	return {
-		ok,
-		report: output.join("\n"),
-	};
+	return output.join("\n");
 }
 
 /**

--- a/src/output.test.js
+++ b/src/output.test.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2025  Eric Cornelissen
+// Copyright (C) 2025-2026  Eric Cornelissen
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
@@ -18,291 +18,301 @@ import { test } from "node:test";
 import { MockStyler } from "./style.mock.js";
 
 import {
-	printAndExit,
+	isSuccess,
+	makeReport,
 } from "./output.js";
 
 test("output.js", (t) => {
-	t.test("printAndExit", (t) => {
-		const styler = MockStyler;
+	const styler = MockStyler;
 
-		const testCases = {
-			"no deprecations": {
-				options: {
-					everything: false,
-				},
-				results: [],
-				unused: [],
-				want: {
-					ok: true,
-					report: ``,
-				}
+	const testCases = {
+		"no deprecations": {
+			options: {
+				everything: false,
 			},
-			"one deprecation which is ignored": {
-				options: {
-					everything: false,
-				},
-				results: [
-					{
-						name: "foobar",
-						version: "3.1.4",
-						reason: "no longer maintained",
-						kept: [],
-						ignored: [
-							{
-								path: [{ name: "foobar", version: "3.1.4" }],
-								reason: "okay for now",
-							}
-						],
-					}
-				],
-				unused: [],
-				want: {
-					ok: true,
-					report: ``,
-				}
+			results: [],
+			unused: [],
+			want: {
+				ok: true,
+				report: ``,
+			}
+		},
+		"one deprecation which is ignored": {
+			options: {
+				everything: false,
 			},
-			"one deprecation which is ignored without a reason": {
-				options: {
-					everything: false,
-				},
-				results: [
-					{
-						name: "foobar",
-						version: "3.1.4",
-						reason: "no longer maintained",
-						kept: [],
-						ignored: [
-							{
-								path: [{ name: "foobar", version: "3.1.4" }],
-								reason: true,
-							}
-						],
-					}
-				],
-				unused: [],
-				want: {
-					ok: true,
-					report: ``,
+			results: [
+				{
+					name: "foobar",
+					version: "3.1.4",
+					reason: "no longer maintained",
+					kept: [],
+					ignored: [
+						{
+							path: [{ name: "foobar", version: "3.1.4" }],
+							reason: "okay for now",
+						}
+					],
 				}
+			],
+			unused: [],
+			want: {
+				ok: true,
+				report: ``,
+			}
+		},
+		"one deprecation which is ignored without a reason": {
+			options: {
+				everything: false,
 			},
-			"one deprecation which is ignored, everything": {
-				options: {
-					everything: true,
+			results: [
+				{
+					name: "foobar",
+					version: "3.1.4",
+					reason: "no longer maintained",
+					kept: [],
+					ignored: [
+						{
+							path: [{ name: "foobar", version: "3.1.4" }],
+							reason: true,
+						}
+					],
+				}
+			],
+			unused: [],
+			want: {
+				ok: true,
+				report: ``,
+			}
+		},
+		"one deprecation which is ignored, everything": {
+			options: {
+				everything: true,
+			},
+			results: [
+				{
+					name: "foobar",
+					version: "3.1.4",
+					reason: "no longer maintained",
+					kept: [],
+					ignored: [
+						{
+							path: [{ name: "foobar", version: "3.1.4" }],
+							reason: "okay for now",
+						}
+					],
 				},
-				results: [
-					{
-						name: "foobar",
-						version: "3.1.4",
-						reason: "no longer maintained",
-						kept: [],
-						ignored: [
-							{
-								path: [{ name: "foobar", version: "3.1.4" }],
-								reason: "okay for now",
-							}
-						],
-					},
-				],
-				unused: [],
-				want: {
-					ok: true,
-					report: `${styler.dim(`foobar@3.1.4 ${styler.italic(`("no longer maintained")`)}:`)}
+			],
+			unused: [],
+			want: {
+				ok: true,
+				report: `${styler.dim(`foobar@3.1.4 ${styler.italic(`("no longer maintained")`)}:`)}
 	${styler.dim(`. > foobar@3.1.4`)}
 		${styler.dim(`(allowed "okay for now")`)}`,
-				}
+			}
+		},
+		"one deprecation which is ignored without a reason, everything": {
+			options: {
+				everything: true,
 			},
-			"one deprecation which is ignored without a reason, everything": {
-				options: {
-					everything: true,
+			results: [
+				{
+					name: "foobar",
+					version: "3.1.4",
+					reason: "no longer maintained",
+					kept: [],
+					ignored: [
+						{
+							path: [{ name: "foobar", version: "3.1.4" }],
+							reason: true,
+						},
+					],
 				},
-				results: [
-					{
-						name: "foobar",
-						version: "3.1.4",
-						reason: "no longer maintained",
-						kept: [],
-						ignored: [
-							{
-								path: [{ name: "foobar", version: "3.1.4" }],
-								reason: true,
-							},
-						],
-					},
-				],
-				unused: [],
-				want: {
-					ok: true,
-					report: `${styler.dim(`foobar@3.1.4 ${styler.italic(`("no longer maintained")`)}:`)}
+			],
+			unused: [],
+			want: {
+				ok: true,
+				report: `${styler.dim(`foobar@3.1.4 ${styler.italic(`("no longer maintained")`)}:`)}
 	${styler.dim(`. > foobar@3.1.4`)}
 		${styler.dim(`(allowed "no reason given")`)}`,
-				}
+			}
+		},
+		"one transitive deprecation which is ignored, everything": {
+			options: {
+				everything: true,
 			},
-			"one transitive deprecation which is ignored, everything": {
-				options: {
-					everything: true,
+			results: [
+				{
+					name: "bar",
+					version: "3.1.4",
+					reason: "no longer maintained",
+					kept: [],
+					ignored: [
+						{
+							path: [
+								{ name: "foo", version: "2.7.1" },
+								{ name: "bar", version: "3.1.4" },
+							],
+							reason: true,
+						}
+					],
 				},
-				results: [
-					{
-						name: "bar",
-						version: "3.1.4",
-						reason: "no longer maintained",
-						kept: [],
-						ignored: [
-							{
-								path: [
-									{ name: "foo", version: "2.7.1" },
-									{ name: "bar", version: "3.1.4" },
-								],
-								reason: true,
-							}
-						],
-					},
-				],
-				unused: [],
-				want: {
-					ok: true,
-					report: `${styler.dim(`bar@3.1.4 ${styler.italic(`("no longer maintained")`)}:`)}
+			],
+			unused: [],
+			want: {
+				ok: true,
+				report: `${styler.dim(`bar@3.1.4 ${styler.italic(`("no longer maintained")`)}:`)}
 	${styler.dim(`. > foo@2.7.1 > bar@3.1.4`)}
 		${styler.dim(`(allowed "no reason given")`)}`,
-				}
+			}
+		},
+		"one deprecation which is not ignored": {
+			options: {
+				everything: false,
 			},
-			"one deprecation which is not ignored": {
-				options: {
-					everything: false,
-				},
-				results: [
-					{
-						name: "foobar",
-						version: "3.1.4",
-						reason: "no longer maintained",
-						kept: [
-							{ path: [{ name: "foobar", version: "3.1.4" }] },
-						],
-						ignored: [],
-					}
-				],
-				unused: [],
-				want: {
-					ok: false,
-					report: `foobar@3.1.4 ${styler.italic(`("no longer maintained")`)}:
+			results: [
+				{
+					name: "foobar",
+					version: "3.1.4",
+					reason: "no longer maintained",
+					kept: [
+						{ path: [{ name: "foobar", version: "3.1.4" }] },
+					],
+					ignored: [],
+				}
+			],
+			unused: [],
+			want: {
+				ok: false,
+				report: `foobar@3.1.4 ${styler.italic(`("no longer maintained")`)}:
 	. > foobar@3.1.4`,
-				}
+			}
+		},
+		"one transitive deprecation which is not ignored": {
+			options: {
+				everything: false,
 			},
-			"one transitive deprecation which is not ignored": {
-				options: {
-					everything: false,
-				},
-				results: [
-					{
-						name: "bar",
-						version: "3.1.4",
-						reason: "no longer maintained",
-						kept: [
-							{
-								path: [
-									{ name: "foo", version: "2.7.1" },
-									{ name: "bar", version: "3.1.4" },
-								],
-							},
-						],
-						ignored: [],
-					}
-				],
-				unused: [],
-				want: {
-					ok: false,
-					report: `bar@3.1.4 ${styler.italic(`("no longer maintained")`)}:
+			results: [
+				{
+					name: "bar",
+					version: "3.1.4",
+					reason: "no longer maintained",
+					kept: [
+						{
+							path: [
+								{ name: "foo", version: "2.7.1" },
+								{ name: "bar", version: "3.1.4" },
+							],
+						},
+					],
+					ignored: [],
+				}
+			],
+			unused: [],
+			want: {
+				ok: false,
+				report: `bar@3.1.4 ${styler.italic(`("no longer maintained")`)}:
 	. > foo@2.7.1 > bar@3.1.4`,
-				}
+			}
+		},
+		"two deprecation which are not ignored (in order)": {
+			options: {
+				everything: false,
 			},
-			"two deprecation which are not ignored (in order)": {
-				options: {
-					everything: false,
+			results: [
+				{
+					name: "bar",
+					version: "3.1.4",
+					reason: "no longer maintained",
+					kept: [
+						{ path: [{ name: "bar", version: "3.1.4" }] }
+					],
+					ignored: [],
 				},
-				results: [
-					{
-						name: "bar",
-						version: "3.1.4",
-						reason: "no longer maintained",
-						kept: [
-							{ path: [{ name: "bar", version: "3.1.4" }] }
-						],
-						ignored: [],
-					},
-					{
-						name: "foo",
-						version: "2.7.1",
-						reason: "not maintained anymore",
-						kept: [
-							{ path: [{ name: "foo", version: "2.7.1" }] }
-						],
-						ignored: [],
-					},
-				],
-				unused: [],
-				want: {
-					ok: false,
-					report: `bar@3.1.4 ${styler.italic(`("no longer maintained")`)}:
+				{
+					name: "foo",
+					version: "2.7.1",
+					reason: "not maintained anymore",
+					kept: [
+						{ path: [{ name: "foo", version: "2.7.1" }] }
+					],
+					ignored: [],
+				},
+			],
+			unused: [],
+			want: {
+				ok: false,
+				report: `bar@3.1.4 ${styler.italic(`("no longer maintained")`)}:
 	. > bar@3.1.4
 foo@2.7.1 ${styler.italic(`("not maintained anymore")`)}:
 	. > foo@2.7.1`,
-				}
+			}
+		},
+		"two deprecation which are not ignored (out of order)": {
+			options: {
+				everything: false,
 			},
-			"two deprecation which are not ignored (out of order)": {
-				options: {
-					everything: false,
+			results: [
+				{
+					name: "foo",
+					version: "2.7.1",
+					reason: "not maintained anymore",
+					kept: [
+						{ path: [{ name: "foo", version: "2.7.1" }] }
+					],
+					ignored: [],
 				},
-				results: [
-					{
-						name: "foo",
-						version: "2.7.1",
-						reason: "not maintained anymore",
-						kept: [
-							{ path: [{ name: "foo", version: "2.7.1" }] }
-						],
-						ignored: [],
-					},
-					{
-						name: "bar",
-						version: "3.1.4",
-						reason: "no longer maintained",
-						kept: [
-							{ path: [{ name: "bar", version: "3.1.4" }] }
-						],
-						ignored: [],
-					},
-				],
-				unused: [],
-				want: {
-					ok: false,
-					report: `bar@3.1.4 ${styler.italic(`("no longer maintained")`)}:
+				{
+					name: "bar",
+					version: "3.1.4",
+					reason: "no longer maintained",
+					kept: [
+						{ path: [{ name: "bar", version: "3.1.4" }] }
+					],
+					ignored: [],
+				},
+			],
+			unused: [],
+			want: {
+				ok: false,
+				report: `bar@3.1.4 ${styler.italic(`("no longer maintained")`)}:
 	. > bar@3.1.4
 foo@2.7.1 ${styler.italic(`("not maintained anymore")`)}:
 	. > foo@2.7.1`,
-				}
+			}
+		},
+		"one unused ignore": {
+			options: {
+				everything: false,
 			},
-			"one unused ignore": {
-				options: {
-					everything: false,
-				},
-				results: [],
-				unused: [
-					["foo@3.1.4", "bar@2.7.1"],
-				],
-				want: {
-					ok: false,
-					report: `Unused ignore directives(s):
+			results: [],
+			unused: [
+				["foo@3.1.4", "bar@2.7.1"],
+			],
+			want: {
+				ok: false,
+				report: `Unused ignore directives(s):
 	. > foo@3.1.4 > bar@2.7.1`,
-				}
-			},
-		};
+			}
+		},
+	};
 
+	t.test("isSuccesss", (t) => {
+		for (const [name, testCase] of Object.entries(testCases)) {
+			const { results, unused, want } = testCase;
+			t.test(name, () => {
+				const got = isSuccess(results, unused);
+				assert.equal(got, want.ok);
+			});
+		}
+	});
+
+	t.test("makeReport", (t) => {
 		for (const [name, testCase] of Object.entries(testCases)) {
 			const { options, results, unused, want } = testCase;
 			t.test(name, () => {
-				const got = printAndExit(results, unused, options, styler);
-				assert.equal(got.ok, want.ok);
-				assert.equal(got.report, want.report);
+				const got = makeReport(results, unused, options, styler);
+				assert.equal(got, want.report);
 			});
 		}
 	});

--- a/src/yarn.js
+++ b/src/yarn.js
@@ -103,7 +103,6 @@ export class Yarn {
 		const { stdout } = result.value();
 		const lines = stdout.trim().split("\n");
 		const dependencies = new Map();
-		let root = null;
 		for (const line of lines) {
 			const json = parseJSON(line);
 			if (json.isErr()) {
@@ -112,12 +111,15 @@ export class Yarn {
 			}
 
 			const dependency = json.value();
-			root = dependency.value;
 			dependencies.set(
 				dependency.value,
 				dependency.children.Dependencies?.map(({ locator }) => locator),
 			);
 		}
+
+		const rootLine = lines.findLast(() => true);
+		const rootJson = parseJSON(rootLine).value();
+		const root = rootJson.value;
 
 		const hierarchy = { dependencies: {} };
 		const queue = [[root, hierarchy]];


### PR DESCRIPTION
I'm using the following command for this process

```shell
podman run -it --rm \
  --workdir '/depreman' \
  --mount 'type=bind,source=.,target=/depreman' \
  --publish '7777:7777' \
  --name 'depreman-eslint-inspector' \
  'docker.io/node:26-alpine' \
  sh -c 'npx --yes @eslint/config-inspector@latest --config .eslintrc.js --host 0.0.0.0'
```