### PR TITLE
Bump `fast-uri` from v3.1.2 to v3.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4245,9 +4245,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Due to CVE-2026-13676 and CVE-2026-16221
Relates to [Audit #1231](https://github.com/ericcornelissen/depreman/actions/runs/29894974987/job/88843096631)

This is **not** a runtime dependency of depreman so there is little to no security concern for its users.